### PR TITLE
Ed25519Private: change to handle public keys

### DIFF
--- a/src/wolfcrypt/_build_ffi.py
+++ b/src/wolfcrypt/_build_ffi.py
@@ -171,6 +171,8 @@ ffi.cdef(
     void wc_ed25519_free(ed25519_key* ed25519);
 
     int wc_ed25519_make_key(WC_RNG* rng, int keysize, ed25519_key* key);
+    int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
+                           word32 pubKeySz);
     int wc_ed25519_size(ed25519_key* key);
     int wc_ed25519_sig_size(ed25519_key* key);
     int wc_ed25519_sign_msg(const byte* in, word32 inlen, byte* out,

--- a/tests/test_ciphers.py
+++ b/tests/test_ciphers.py
@@ -355,7 +355,8 @@ def test_ed25519_key_encoding(vectors):
     priv.decode_key(vectors[Ed25519Private].key)
     pub.decode_key(vectors[Ed25519Public].key)
 
-    assert priv.encode_key() == vectors[Ed25519Private].key
+    assert priv.encode_key()[0] == vectors[Ed25519Private].key
+    assert priv.encode_key()[1] == vectors[Ed25519Public].key # Automatically re-generated from private-only
     assert pub.encode_key() == vectors[Ed25519Public].key
 
 


### PR DESCRIPTION
Ed25519 class can now handle the pubic key part as well. This allows to store a complete key created with Ed25519.make_key() in two separate buffers (priv + public).

Please consider for merge.

Thanks,

/d