### PR TITLE
[ECC] Added ecc_sign_raw and ecc_verify_raw + test cases

### DIFF
--- a/src/wolfcrypt/_build_ffi.py
+++ b/src/wolfcrypt/_build_ffi.py
@@ -59,6 +59,11 @@ ffi.cdef(
     typedef unsigned char byte;
     typedef unsigned int word32;
 
+    typedef struct { ...; } mp_int;
+
+    int mp_init (mp_int * a);
+    int mp_to_unsigned_bin (mp_int * a, unsigned char *b);
+    int mp_read_unsigned_bin (mp_int * a, const unsigned char *b, int c);
 
     typedef struct { ...; } wc_Sha;
 
@@ -94,6 +99,7 @@ ffi.cdef(
     int wc_HmacSetKey(Hmac*, int, const byte*, word32);
     int wc_HmacUpdate(Hmac*, const byte*, word32);
     int wc_HmacFinal(Hmac*, byte*);
+
 
 
     typedef struct { ...; } Aes;
@@ -172,8 +178,14 @@ ffi.cdef(
                            const byte* hash, word32 hashlen,
                            int* stat, ecc_key* key);
 
+    int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
+                     ecc_key* key, mp_int *r, mp_int *s);
+
+    int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
+                    word32 hashlen, int* res, ecc_key* key);
+
     typedef struct {...; } ed25519_key;
-    
+
     int wc_ed25519_init(ed25519_key* ed25519);
     void wc_ed25519_free(ed25519_key* ed25519);
 

--- a/tests/test_ciphers.py
+++ b/tests/test_ciphers.py
@@ -349,6 +349,23 @@ def test_ecc_sign_verify(ecc_private, ecc_public):
     with pytest.raises(WolfCryptError):
         ecc_x963.import_x963(ecc_public.export_x963()[:-1])
 
+def test_ecc_sign_verify_raw(ecc_private, ecc_public):
+    plaintext = "Everyone gets Friday off."
+
+    # normal usage, sign with private, verify with public
+    r,s = ecc_private.sign_raw(plaintext)
+
+    assert len(r) + len(s) <= 2 * ecc_private.size
+    assert ecc_public.verify_raw(r, s, plaintext)
+
+    # invalid signature
+    ret = ecc_public.verify_raw(r, s[:-1], plaintext)
+    assert ret == False
+
+    # private object holds both private and public info, so it can also verify
+    # using the known public key.
+    assert ecc_private.verify_raw(r, s, plaintext)
+
 
 def test_ecc_make_shared_secret():
     a = EccPrivate.make_key(32)


### PR DESCRIPTION
ECC signature can be represented by its two raw components R,S.
This patch adds two methods `R,S = EccPrivate.sign_raw(plaintext)` and `EccPublic.verify_raw(R,S,plaintext)`

Test added for sign_raw/verify_raw case.

