### PR TITLE
Build Update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ We provide Python wheels (prebuilt binaries) for OSX 64 bits and Linux 64 bits:
 To build wolfcrypt-py against a local installation of the native C wolfSSL
 library, use the USE_LOCAL_WOLFSSL variable.  This variable should be
 
-wolfcrypt-py can be built against a local verison of the native wolfSSL
+wolfcrypt-py can be built against a local version of the native wolfSSL
 library by using pip with the USE_LOCAL_WOLFSSL variable. USE_LOCAL_WOLFSSL
 should be set equal to the installation path for the wolfSSL library:
 

--- a/make/manylinux1/build_wheels.sh
+++ b/make/manylinux1/build_wheels.sh
@@ -6,5 +6,5 @@ docker run \
     --rm \
     -v `pwd`:/wolfcrypt-py \
     -w /wolfcrypt-py \
-    quay.io/pypa/manylinux1_x86_64 \
+    wolfssl/manylinux1-x86_64 \
     bash -c "make/manylinux1/build.sh"

--- a/make/osx/build_wheels.sh
+++ b/make/osx/build_wheels.sh
@@ -1,17 +1,22 @@
 set -e
 set +x
 
-for PYVERSION in 2.7 3.6 3.7; do
-    virtualenv -p /Library/Frameworks/Python.framework/Versions/${PYVERSION}/bin/python${PYVERSION} venv_${PYVERSION}
-    . ./venv_${PYVERSION}/bin/activate
-    curl https://bootstrap.pypa.io/get-pip.py | python
-    pip install -r requirements/setup.txt
-    python setup.py bdist_wheel
-    pip install -r requirements/test.txt
+for VER in 2.7 3.6 3.7; do
+    PIP="pip${VER}"
+    PYTHON="python${VER}"
+    VENV="venv_${VER}"
+
+    ${PIP} install virtualenv
+    virtualenv -p ${PYTHON} ${VENV}
+    . ./${VENV}/bin/activate
+    curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON}
+    ${PIP} install -r requirements/setup.txt
+    ${PYTHON} setup.py bdist_wheel
+    ${PIP} install -r requirements/test.txt
     set +e
-    pip uninstall -y wolfcrypt
+    ${PIP} uninstall -y wolfcrypt
     set -e
-    pip install wolfcrypt --no-index -f dist
+    ${PIP} install wolfcrypt --no-index -f dist
     rm -rf tests/__pycache__
     py.test tests
     deactivate

--- a/make/osx/build_wheels.sh
+++ b/make/osx/build_wheels.sh
@@ -6,11 +6,15 @@ for VER in 2.7 3.6 3.7; do
     PYTHON="python${VER}"
     VENV="venv_${VER}"
 
-    ${PIP} install virtualenv
-    virtualenv -p ${PYTHON} ${VENV}
-    . ./${VENV}/bin/activate
+    # update pip for newer TLS support
     curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON}
     ${PIP} install -r requirements/setup.txt
+
+    # update virtualenv
+    ${PIP} install --upgrade virtualenv
+    virtualenv -p ${PYTHON} ${VENV}
+    . ./${VENV}/bin/activate
+
     ${PYTHON} setup.py bdist_wheel
     ${PIP} install -r requirements/test.txt
     set +e


### PR DESCRIPTION
1. Use the same docker image as the wolfSSL python project.
2. Remove the absolute path to the python interpreter. They just need to be in the path. (For example, you might install old versions in /opt and add their subdirs to the path while the latest runs out of its location.)