### PR TITLE
Modernize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,16 @@
-sudo: required
+language: generic
 
-branches:
-  only:
-    - master
-
-matrix:
-  include:
-    - dist: trusty
-      language: python
-      services:
-        - docker
-      script:
-        - ./make/manylinux1/build_wheels.sh
-    - os: osx
-      osx_image: xcode8.3
-      script:
-        - ./make/osx/build_wheels.sh
-
+jobs:
+    include:
+        - os: linux
+          language: python
+          services:
+              - docker
+          script:
+              - ./make/manylinux1/build_wheels.sh
+        - os: osx
+          osx_image: xcode9.4
+          script:
+              - ./make/osx/build_wheels.sh
 install:
   - if [ "${TRAVIS_OS_NAME:-}" == "osx" ]; then ./make/osx/install_python.sh; fi

--- a/make/osx/build_wheels.sh
+++ b/make/osx/build_wheels.sh
@@ -1,10 +1,11 @@
 set -e
 set +x
 
-for VER in 2.7 3.6 3.7; do
+for VER in 2.7 3.7 3.8; do
     PIP="pip${VER}"
     PYTHON="python${VER}"
     VENV="venv_${VER}"
+    PATH="/Library/Frameworks/Python.framework/Versions/${VER}/bin:$PATH"
 
     # update pip for newer TLS support
     curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON}

--- a/make/osx/install_python.sh
+++ b/make/osx/install_python.sh
@@ -3,10 +3,9 @@ set -euo pipefail
 set -x
 
 URLS=(
-    'https://www.python.org/ftp/python/2.7.15/python-2.7.15-macosx10.6.pkg'
-    'https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg'
-    'https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.6.pkg'
-    'https://www.python.org/ftp/python/3.7.0/python-3.7.0-macosx10.6.pkg'
+    'https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg'
+    'https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg'
+    'https://www.python.org/ftp/python/3.8.6/python-3.8.6-macosx10.9.pkg'
 )
 
 for url in "${URLS[@]}"; do


### PR DESCRIPTION
1. Update the travis script to follow their multi-OS example.
2. Set the path to Python in the osx bulid wheels script.
3. For osx, removed all versions of python except 2.7, 3.7, and 3.8.