### PR TITLE
remove python 2.7 from make/osx scripts

### DIFF
--- a/make/osx/build_wheels.sh
+++ b/make/osx/build_wheels.sh
@@ -1,7 +1,7 @@
 set -e
 set +x
 
-for VER in 2.7 3.7 3.8; do
+for VER in 3.7 3.8; do
     PIP="pip${VER}"
     PYTHON="python${VER}"
     VENV="venv_${VER}"

--- a/make/osx/install_python.sh
+++ b/make/osx/install_python.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 set -x
 
 URLS=(
-    'https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg'
     'https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg'
     'https://www.python.org/ftp/python/3.8.6/python-3.8.6-macosx10.9.pkg'
 )


### PR DESCRIPTION
This PR removes Python 2.7 from the make/osx scripts.  Python 2.7 reached End of Life on January 1, 2020.  pip 21.0 dropped support for Python 2.7 in January 2021.