### PR TITLE
Minor fixups to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py39, pep8
-skipsdist = True
+envlist = py3
 
 [testenv]
 setenv =


### PR DESCRIPTION
1. sdist based build/test works now. Better to use that.
2. switch to py3 instead of py39 to better suit older versions.
3. remove pep8 testing for now, some more work needed for that.