### PR TITLE
Fix missing class members from docs

### DIFF
--- a/docs/digest.rst
+++ b/docs/digest.rst
@@ -22,6 +22,8 @@ interface:
 
 .. autoclass:: _Hash
     :members:
+    :inherited-members:
+
 
 SHA-1
 ~~~~~
@@ -32,17 +34,25 @@ SHA-1
     are strongly suggested to use SHA-2 over SHA-1.
 
 .. autoclass:: Sha
+    :members:
+    :inherited-members:
 
 SHA-2 family
 ~~~~~~~~~~~~
 
 .. autoclass:: Sha256
+    :members:
+    :inherited-members:
 
 
 .. autoclass:: Sha384
+    :members:
+    :inherited-members:
 
 
 .. autoclass:: Sha512
+   :members:
+   :inherited-members:
 
 
 Example

--- a/docs/random.rst
+++ b/docs/random.rst
@@ -14,6 +14,7 @@ vectors can result in major security issues depending on the algorithms in use.
 
 .. autoclass:: Random
     :members:
+    :inherited-members:
 
 
 Example

--- a/docs/symmetric.rst
+++ b/docs/symmetric.rst
@@ -18,12 +18,14 @@ interface:
 
 .. autoclass:: _Cipher
     :members:
+    :inherited-members:
 
 AES
 ~~~
 
 .. autoclass:: Aes
     :members:
+    :inherited-members:
 
 **Example:**
 
@@ -43,6 +45,7 @@ Triple DES
 
 .. autoclass:: Des3
     :members:
+    :inherited-members:
 
 **Example:**
 


### PR DESCRIPTION
Inherited class members were missing from class documentation. Most
classes rely on these so this makes them visible in the docs.