### PR TITLE
Completely refactor AES GCM

### DIFF
--- a/docs/streaming.rst
+++ b/docs/streaming.rst
@@ -9,10 +9,10 @@ Steaming Encryption Classes
 Interface
 ~~~~~~~~~
 
-AesGcmStreamEncrypt
-~~~~~~~~~~~~~~~~~~~
+AesGcmStream
+~~~~~~~~~~~~
 
-.. autoclass:: AesGcmStreamEncrypt
+.. autoclass:: AesGcmStream
     :members:
     :inherited-members:
 
@@ -22,29 +22,15 @@ AesGcmStreamEncrypt
 
     >>> from wolfcrypt.ciphers import AesGcmStreamEncrypt
     >>> from binascii import hexlify as b2h
-    >>> gcm = AesGcmStreamEncrypt(b'fedcba9876543210', b'0123456789abcdef')
-    >>> buf = gcm.update("hello world")
+    >>> gcm = AesGcmStream(b'fedcba9876543210', b'0123456789abcdef')
+    >>> buf = gcm.encrypt("hello world")
     >>> authTag = gcm.final()
     >>> b2h(buf)
     b'5ba7d42e1bf01d7998e932'
     >>> b2h(authTag)
-    b'cef91ba0c8c6431c7e19f64c9d9e371b'
-
-AesGcmStreamDecrypt
-~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: AesGcmStreamDecrypt
-    :members:
-    :inherited-members:
-
-**Example:**
-
-.. doctest::
-
-    >>> from wolfcrypt.ciphers import AesGcmStreamDecrypt, t2b
-    >>> from binascii import unhexlify as h2b
-    >>> gcm = AesGcmStreamDecrypt(b'fedcba9876543210', b'0123456789abcdef')
-    >>> buf = gcm.update(h2b(b'5ba7d42e1bf01d7998e932'))
-    >>> gcm.final(h2b(b'cef91ba0c8c6431c7e19f64c9d9e371b'))
+    b'8f85338aa0b13f48f8b17482dbb8acca'
+    >>> gcm = AesGcmStream(b'fedcba9876543210', b'0123456789abcdef')
+    >>> buf = gcm.decrypt(h2b(b'5ba7d42e1bf01d7998e932'))
+    >>> gcm.final(h2b(b'8f85338aa0b13f48f8b17482dbb8acca'))
     >>> t2b(buf)
     b'hello world'

--- a/tests/test_aesgcmstream.py
+++ b/tests/test_aesgcmstream.py
@@ -25,34 +25,101 @@ import pytest
 from wolfcrypt._ffi import ffi as _ffi
 from wolfcrypt._ffi import lib as _lib
 from wolfcrypt.utils import t2b
+from wolfcrypt.exceptions import WolfCryptError
 from binascii import hexlify as b2h, unhexlify as h2b
 
-from wolfcrypt.ciphers import AesGcmStreamEncrypt, AesGcmStreamDecrypt
+from wolfcrypt.ciphers import AesGcmStream
 
 def test_encrypt():
     key = "fedcba9876543210"
     iv = "0123456789abcdef"
-    gcm = AesGcmStreamEncrypt(key, iv)
-    buf = gcm.update("hello world")
+    gcm = AesGcmStream(key, iv)
+    buf = gcm.encrypt("hello world")
     authTag = gcm.final()
-    assert b2h(authTag) == bytes('cef91ba0c8c6431c7e19f64c9d9e371b', 'utf-8')
+    assert b2h(authTag) == bytes('ac8fcee96dc6ef8e5236da19b6197d2e', 'utf-8')
     assert b2h(buf) == bytes('5ba7d42e1bf01d7998e932', "utf-8")
-    gcmdec = AesGcmStreamDecrypt(key, iv)
-    bufdec = gcmdec.update(buf)
+    gcmdec = AesGcmStream(key, iv)
+    bufdec = gcmdec.decrypt(buf)
+    gcmdec.final(authTag)
+    assert bufdec == t2b("hello world")
+
+def test_encrypt_short_tag():
+    key = "fedcba9876543210"
+    iv = "0123456789abcdef"
+    gcm = AesGcmStream(key, iv, 12)
+    buf = gcm.encrypt("hello world")
+    authTag = gcm.final()
+    assert b2h(authTag) == bytes('ac8fcee96dc6ef8e5236da19', 'utf-8')
+    assert b2h(buf) == bytes('5ba7d42e1bf01d7998e932', "utf-8")
+    gcmdec = AesGcmStream(key, iv)
+    bufdec = gcmdec.decrypt(buf)
     gcmdec.final(authTag)
     assert bufdec == t2b("hello world")
 
 def test_multipart():
     key = "fedcba9876543210"
     iv = "0123456789abcdef"
-    gcm = AesGcmStreamEncrypt(key, iv)
-    buf = gcm.update("hello")
-    buf += gcm.update(" world")
+    gcm = AesGcmStream(key, iv)
+    buf = gcm.encrypt("hello")
+    buf += gcm.encrypt(" world")
     authTag = gcm.final()
-    assert b2h(authTag) == bytes('6862647a27c7b6aa0a6882b3e117e944', 'utf-8')
+    assert b2h(authTag) == bytes('ac8fcee96dc6ef8e5236da19b6197d2e', 'utf-8')
     assert b2h(buf) == bytes('5ba7d42e1bf01d7998e932', "utf-8")
-    gcmdec = AesGcmStreamDecrypt(key, iv)
-    bufdec = gcmdec.update(buf[:5])
-    bufdec += gcmdec.update(buf[5:])
+    gcmdec = AesGcmStream(key, iv)
+    bufdec = gcmdec.decrypt(buf[:5])
+    bufdec += gcmdec.decrypt(buf[5:])
     gcmdec.final(authTag)
     assert bufdec == t2b("hello world")
+
+def test_encrypt_aad():
+    key = "fedcba9876543210"
+    iv = "0123456789abcdef"
+    aad = "aad data"
+    gcm = AesGcmStream(key, iv)
+    gcm.set_aad(aad)
+    buf = gcm.encrypt("hello world")
+    authTag = gcm.final()
+    print(b2h(authTag))
+    assert b2h(authTag) == bytes('8f85338aa0b13f48f8b17482dbb8acca', 'utf-8')
+    assert b2h(buf) == bytes('5ba7d42e1bf01d7998e932', "utf-8")
+    gcmdec = AesGcmStream(key, iv)
+    gcmdec.set_aad(aad)
+    bufdec = gcmdec.decrypt(buf)
+    gcmdec.final(authTag)
+    assert bufdec == t2b("hello world")
+
+def test_multipart_aad():
+    key = "fedcba9876543210"
+    iv = "0123456789abcdef"
+    aad = "aad data"
+    gcm = AesGcmStream(key, iv)
+    gcm.set_aad(aad)
+    buf = gcm.encrypt("hello")
+    buf += gcm.encrypt(" world")
+    authTag = gcm.final()
+    assert b2h(authTag) == bytes('8f85338aa0b13f48f8b17482dbb8acca', 'utf-8')
+    assert b2h(buf) == bytes('5ba7d42e1bf01d7998e932', "utf-8")
+    gcmdec = AesGcmStream(key, iv)
+    gcmdec.set_aad(aad)
+    bufdec = gcmdec.decrypt(buf[:5])
+    bufdec += gcmdec.decrypt(buf[5:])
+    gcmdec.final(authTag)
+    assert bufdec == t2b("hello world")
+
+def test_encrypt_aad_bad():
+    key = "fedcba9876543210"
+    iv = "0123456789abcdef"
+    aad = "aad data"
+    aad_bad = "bad data"
+    gcm = AesGcmStream(key, iv)
+    gcm.set_aad(aad)
+    buf = gcm.encrypt("hello world")
+    authTag = gcm.final()
+    print(b2h(authTag))
+    assert b2h(authTag) == bytes('8f85338aa0b13f48f8b17482dbb8acca', 'utf-8')
+    assert b2h(buf) == bytes('5ba7d42e1bf01d7998e932', "utf-8")
+    gcmdec = AesGcmStream(key, iv)
+    gcmdec.set_aad(aad_bad)
+    gcmdec.decrypt(buf)
+    with pytest.raises(WolfCryptError):
+        gcmdec.final(authTag)


### PR DESCRIPTION
Some bad assumptions were made during the creation of our Python AES GCM
code. This is now modified to be more in-line with other libraries. This
is an API breaking change on unreleased code.

This now allows for aad data to be used, varying length of
authentication tags and fixes a bug for multipart.

1. Now unified to a single class AesGcmStream()
2. Used `encrypt()` and `decrypt()` instead of `update()` to avoid
   confusion over encryption and aad semantics
3. final tag_bytes is configurable in the constructor
4. `set_aad()` added to add the aad data
5. aad data is cleared after first `encrypt()` or `decrypt()` call due
   to quirk in the C API.
6. More tests added