### PR TITLE
Add optional hash_type parameter to RSA from_pem functions.

### DIFF
--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -521,9 +521,9 @@ if _lib.RSA_ENABLED:
 
         if _lib.ASN_ENABLED:
             @classmethod
-            def from_pem(cls, file):
+            def from_pem(cls, file, hash_type=None):
                 der = pem_to_der(file, _lib.PUBLICKEY_TYPE)
-                return cls(der)
+                return cls(key=der, hash_type=hash_type)
 
         def encrypt(self, plaintext):
             """
@@ -670,9 +670,9 @@ if _lib.RSA_ENABLED:
 
         if _lib.ASN_ENABLED:
             @classmethod
-            def from_pem(cls, file):
+            def from_pem(cls, file, hash_type=None):
                 der = pem_to_der(file, _lib.PRIVATEKEY_TYPE)
-                return cls(der)
+                return cls(key=der, hash_type=hash_type)
 
         if _lib.KEYGEN_ENABLED:
             def encode_key(self):


### PR DESCRIPTION
The hash type was made part of the RSA constructor a little while back. This provides a way to initialize the hash type using the from_pem functions and this new constructor.

Fixes ZD #14758.