### PR TITLE
Improve the RSA PSS code.

### DIFF
--- a/tests/test_ciphers.py
+++ b/tests/test_ciphers.py
@@ -450,7 +450,7 @@ if _lib.RSA_ENABLED:
 
     if _lib.RSA_PSS_ENABLED:
         def test_rsa_pss_sign_verify(rsa_private_pss, rsa_public_pss):
-            plaintext = t2b("Everyone gets Friday off yippee.")
+            plaintext = t2b("Everyone gets Friday off.")
 
             # normal usage, sign with private, verify with public
             signature = rsa_private_pss.sign_pss(plaintext)

--- a/wolfcrypt/hashes.py
+++ b/wolfcrypt/hashes.py
@@ -377,3 +377,17 @@ if _lib.HMAC_ENABLED:
             """
             _type = _TYPE_SHA512
             digest_size = Sha512.digest_size
+
+def hash_type_to_cls(hash_type):
+    if _lib.SHA_ENABLED and hash_type == _lib.WC_HASH_TYPE_SHA:
+        hash_cls = Sha
+    elif _lib.SHA256_ENABLED and hash_type == _lib.WC_HASH_TYPE_SHA256:
+        hash_cls = Sha256
+    elif _lib.SHA384_ENABLED and hash_type == _lib.WC_HASH_TYPE_SHA384:
+        hash_cls = Sha384
+    elif _lib.SHA512_ENABLED and hash_type == _lib.WC_HASH_TYPE_SHA512:
+        hash_cls = Sha512
+    else:
+        hash_cls = None
+
+    return hash_cls


### PR DESCRIPTION
- sign_pss and verify_pss need to digest the data before calling into their respective wolfCrypt functions. Those wolfCrypt functions expect digests, not plaintext.
- RsaPrivate make_key should take an optional hash_type parameter for the case where the key will be used to create PSS signatures.
- test_rsa_pss_sign_verify appears to have been deliberately coded to have the input plaintext length line up with the digest size, which masked the problem where we weren't digesting the plaintext. I modified the plaintext so that this is no longer the case.