### PR TITLE
Exclude AES CTR from block size check

### DIFF
--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -181,7 +181,7 @@ class _Cipher(object):
             raise ValueError(
                     "empty string not allowed")
 
-        if len(string) % self.block_size and not "ChaCha" in self._native_type:
+        if len(string) % self.block_size and not self.mode == MODE_CTR and not "ChaCha" in self._native_type:
             raise ValueError(
                 "string must be a multiple of %d in length" % self.block_size)
 
@@ -214,7 +214,7 @@ class _Cipher(object):
             raise ValueError(
                     "empty string not allowed")
 
-        if len(string) % self.block_size and not "ChaCha" in self._native_type:
+        if len(string) % self.block_size and not self.mode == MODE_CTR and not "ChaCha" in self._native_type:
             raise ValueError(
                 "string must be a multiple of %d in length" % self.block_size)
 


### PR DESCRIPTION
If encrypt or decrypt is AES CTR, then the input size does not need to be multiple of block size.

Fixes #59 