### PR TITLE
build_ffi.py: Fix header parsing in feature detection logic

### DIFF
--- a/scripts/build_ffi.py
+++ b/scripts/build_ffi.py
@@ -346,10 +346,10 @@ def get_features(local_wolfssl, features):
         e = "No options.h or user_settings.h found for feature detection."
         raise RuntimeError(e)
 
-    defines = ""
+    defines = []
     for file in defines_files:
         with open(file, 'r') as f:
-            defines += f.read()
+            defines += f.read().splitlines()
 
     features["MPAPI"] = 1 if '#define WOLFSSL_PUBLIC_MP' in defines else 0
     features["SHA"] = 0 if '#define NO_SHA' in defines else 1


### PR DESCRIPTION
`defines` was a string instead of a list of strings. This made it impossible to build a wrapper with a configuration in which AES-CBC is disabled, because `'#define NO_AES' in defines` matched also when the header contains `#define NO_AES_CBC`. With `defines` being a list the code actually does what you think it does.