### PR TITLE
Move some cdef declarations for RSA to separate section

### DIFF
--- a/scripts/build_ffi.py
+++ b/scripts/build_ffi.py
@@ -957,21 +957,17 @@ def build_ffi(local_wolfssl, features):
 
         word32 wc_EncodeSignature(byte* out, const byte* digest, word32 digSz,
                                   int hashOID);
+        int wc_PemToDer(const unsigned char* buff, long longSz, int type,
+                        DerBuffer** pDer, void* heap, EncryptedInfo* info,
+                        int* keyFormat);
+        int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
+                        byte *cipher_info, int type);
         """
 
     if features["ASN"] or features["RSA"]:
         # This ASN function is used by the RSA binding as well.
         cdef += """
         int wc_GetPkcs8TraditionalOffset(byte* input, word32* inOutIdx, word32 sz);
-        """
-
-    if features["KEYGEN"]:
-        cdef += """
-        int wc_PemToDer(const unsigned char* buff, long longSz, int type,
-                        DerBuffer** pDer, void* heap, EncryptedInfo* info,
-                        int* keyFormat);
-        int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
-                          byte *cipher_info, int type);
         """
 
     if features["WC_RNG_SEED_CB"]:


### PR DESCRIPTION
The definitions for the following functions are not always available when wolfSSL is configured to only contain a minimum of functionality:
- wc_GetPkcs8TraditionalOffset (only with ASN, which is required for RSA)
- wc_PemToDer (only when KEYGEN is enabled)
- wc_DerToPemEx (only when KEYGEN is enabled)

This change allows for building the Python wrapper when ASN and RSA are both disabled.