### PR TITLE
AES-SIV: correct error in key size check

### DIFF
--- a/tests/test_ciphers.py
+++ b/tests/test_ciphers.py
@@ -734,8 +734,14 @@ if _lib.ED448_ENABLED:
 
 
 @pytest.mark.skipif(not _lib.AES_SIV_ENABLED, reason="AES-SIV not enabled")
-def test_aessiv_encrypt_decrypt():
-    key = random.randbytes(32)
+@pytest.mark.parametrize("key_size", [256 // 8, 384 // 8, 512 // 8])
+def test_aessiv_encrypt_decrypt(key_size):
+    """
+    Test that data encrypted by AES-SIV can be decrypted.
+
+    :param key_size: AES-SIV key size in bytes.
+    """
+    key = random.randbytes(key_size)
     aessiv = AesSiv(key)
     associated_data = random.randbytes(16)
     nonce = random.randbytes(12)

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -280,7 +280,8 @@ if _lib.AES_SIV_ENABLED:
         """
         AES-SIV (Synthetic Initialization Vector) implementation as described in RFC 5297.
         """
-        _key_sizes = [16, 24, 32]
+        # RFC 5297 defines key sizes of 256-, 384-, or 512 bits.
+        _key_sizes = [32, 48, 64]
         block_size = 16
 
         def __init__(self, key):


### PR DESCRIPTION
Adjust the code to match the key sizes in the RFC. Update test to cover this.

Previous key sizes were copied from definition in AES class but AES-SIV keys are twice the size.