### PR TITLE
Fix t2b to support other types

### DIFF
--- a/wolfcrypt/utils.py
+++ b/wolfcrypt/utils.py
@@ -18,21 +18,18 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-# pylint: disable=unused-import, undefined-variable
+# pylint: disable=unused-import
 
-import sys
 from binascii import hexlify as b2h, unhexlify as h2b  # noqa: F401
-
-
-_PY3 = sys.version_info[0] == 3
-_TEXT_TYPE = str if _PY3 else unicode  # noqa: F821
-_BINARY_TYPE = bytes if _PY3 else str
 
 
 def t2b(string):
     """
     Converts text to binary.
+
+    Passes through bytes, bytearray, and memoryview unchanged.
+    Encodes str to UTF-8 bytes.
     """
-    if isinstance(string, _BINARY_TYPE):
+    if isinstance(string, (bytes, bytearray, memoryview)):
         return string
-    return _TEXT_TYPE(string).encode("utf-8")
+    return str(string).encode("utf-8")


### PR DESCRIPTION
# Summary of Changes
1. wolfcrypt/utils.py - Updated t2b() function
The t2b() function now passes through bytes, bytearray, and memoryview types unchanged, instead of only accepting bytes. This allows interfaces throughout the codebase that use t2b() to automatically support these additional buffer types.
Also dropped Python 2 compatibility code since it's no longer needed.
2. wolfcrypt/ciphers.py - Fixed ChaCha20Poly1305 class
The ChaCha20Poly1305 class needed to wrap input arguments in _ffi.from_buffer() when passing them to C functions. This is required because CFFI's from_buffer() converts Python buffer objects (including memoryview and bytearray) to C-compatible pointers.
These changes allow memoryview and bytearray types to be used with MlKemPublic.decode_key(), ChaCha20Poly1305.decrypt(), and other interfaces that accept binary data.

Cursor assisted PR

Fixes #81 