### PR TITLE
Fix mutable arguments passed as default arguments.

### DIFF
--- a/tests/test_ciphers.py
+++ b/tests/test_ciphers.py
@@ -614,12 +614,11 @@ if _lib.ECC_ENABLED:
 
 
     def test_ecc_make_shared_secret():
-        rng = Random()
-        a = EccPrivate.make_key(32, rng=rng)
+        a = EccPrivate.make_key(32, rng=Random())
         a_pub = EccPublic()
         a_pub.import_x963(a.export_x963())
 
-        b = EccPrivate.make_key(32, rng=rng)
+        b = EccPrivate.make_key(32, rng=Random())
         b_pub = EccPublic()
         b_pub.import_x963(b.export_x963())
 
@@ -627,6 +626,13 @@ if _lib.ECC_ENABLED:
             == b.shared_secret(a) \
             == a.shared_secret(b_pub) \
             == b.shared_secret(a_pub)
+
+    def test_ecc_make_key_no_rng():
+        key = EccPrivate.make_key(32)
+        pub_key = EccPublic()
+        pub_key.import_x963(key.export_x963())
+
+        assert key.shared_secret(pub_key)
 
 if _lib.ED25519_ENABLED:
     @pytest.fixture

--- a/tests/test_ciphers.py
+++ b/tests/test_ciphers.py
@@ -25,6 +25,7 @@ import random
 import pytest
 from wolfcrypt._ffi import lib as _lib
 from wolfcrypt.ciphers import MODE_CTR, MODE_ECB, MODE_CBC, WolfCryptError
+from wolfcrypt.random import Random
 from wolfcrypt.utils import t2b, h2b
 import os
 
@@ -613,11 +614,12 @@ if _lib.ECC_ENABLED:
 
 
     def test_ecc_make_shared_secret():
-        a = EccPrivate.make_key(32)
+        rng = Random()
+        a = EccPrivate.make_key(32, rng=rng)
         a_pub = EccPublic()
         a_pub.import_x963(a.export_x963())
 
-        b = EccPrivate.make_key(32)
+        b = EccPrivate.make_key(32, rng=rng)
         b_pub = EccPublic()
         b_pub.import_x963(b.export_x963())
 

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -2450,6 +2450,8 @@ if _lib.ML_DSA_ENABLED:
             :return: signature
             :rtype: bytes
             """
+            if rng is None:
+                rng = Random()
             msg_bytestype = t2b(message)
             in_size = self.sig_size
             signature = _ffi.new(f"byte[{in_size}]")

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -1232,8 +1232,6 @@ if _lib.ECC_ENABLED:
 
         def __init__(self, key=None, rng=None):
             super().__init__(key)
-            if rng is None:
-                rng = Random()
             self._rng = rng
 
         @classmethod
@@ -1241,7 +1239,10 @@ if _lib.ECC_ENABLED:
             """
             Generates a new key pair of desired length **size**.
             """
+            if rng is None:
+                rng = Random()
             ecc = cls(rng=rng)
+
             ret = _lib.wc_ecc_make_key(ecc._rng.native_object, size,
                     ecc.native_object)
             if ret < 0:

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -1229,30 +1229,29 @@ if _lib.ECC_ENABLED:
 
 
     class EccPrivate(EccPublic):
+
+        def __init__(self, key=None, rng=None):
+            super().__init__(key)
+            if rng is None:
+                rng = Random()
+            self._rng = rng
+
         @classmethod
         def make_key(cls, size, rng=None):
             """
             Generates a new key pair of desired length **size**.
             """
-            if rng is None:
-                rng = Random()
-            ecc = cls()
-
-            ret = _lib.wc_ecc_make_key(rng.native_object, size,
+            ecc = cls(rng=rng)
+            ret = _lib.wc_ecc_make_key(ecc._rng.native_object, size,
                     ecc.native_object)
             if ret < 0:
                 raise WolfCryptError("Key generation error (%d)" % ret)
 
             if _lib.ECC_TIMING_RESISTANCE_ENABLED and (not _lib.FIPS_ENABLED or
                _lib.FIPS_VERSION > 2):
-                ret = _lib.wc_ecc_set_rng(ecc.native_object, rng.native_object)
+                ret = _lib.wc_ecc_set_rng(ecc.native_object, ecc._rng.native_object)
                 if ret < 0:
                     raise WolfCryptError("Error setting ECC RNG (%d)" % ret)
-
-            # Retain the RNG so it outlives the ECC key. Even outside the
-            # timing-resistance path, wolfSSL internals may retain a pointer
-            # to the RNG; keeping the reference avoids any UAF risk.
-            ecc._rng = rng
 
             return ecc
 
@@ -2450,8 +2449,6 @@ if _lib.ML_DSA_ENABLED:
             :return: signature
             :rtype: bytes
             """
-            if rng is None:
-                rng = Random()
             msg_bytestype = t2b(message)
             in_size = self.sig_size
             signature = _ffi.new(f"byte[{in_size}]")


### PR DESCRIPTION
Function defaults are evaluated once, when the function is defined.

The same mutable object is then shared across all calls to the function. If the object is modified, those modifications will persist across calls, which can lead to unexpected behavior.