### PR TITLE
Fix various minor issues caught by `ruff check` in default mode.

### DIFF
--- a/scripts/build_ffi.py
+++ b/scripts/build_ffi.py
@@ -81,7 +81,7 @@ def wolfssl_lib_dir(local_wolfssl=None, fips=False):
             lib_names.append("libwolfssl.so")
 
         found = False
-        for root, dirs, files in os.walk(local_wolfssl):
+        for root, _dirs, files in os.walk(local_wolfssl):
             for name in lib_names:
                 if name in files:
                     lib_dir = root

--- a/tests/test_ciphers.py
+++ b/tests/test_ciphers.py
@@ -605,7 +605,7 @@ if _lib.ECC_ENABLED:
 
             # invalid signature
             ret = ecc_public.verify_raw(r, s[:-1], plaintext)
-            assert ret == False
+            assert not ret
 
             # private object holds both private and public info, so it can also verify
             # using the known public key.

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -183,7 +183,7 @@ class _Cipher(object):
             raise ValueError(
                     "empty string not allowed")
 
-        if len(string) % self.block_size and not self.mode == MODE_CTR and not "ChaCha" in self._native_type:
+        if len(string) % self.block_size and not self.mode == MODE_CTR and "ChaCha" not in self._native_type:
             raise ValueError(
                 "string must be a multiple of %d in length" % self.block_size)
 


### PR DESCRIPTION
Fixing these minor issues helps in adding more checks to fix-up the code without being bothered by these issues.

Two minor issues are fixed:
- Mark unused variables with a leading underscore
- Use idiomatic boolean expressions