### PR TITLE
Add missing definition ML_DSA_KEYGEN_SEED_LENGTH.

### DIFF
--- a/scripts/build_ffi.py
+++ b/scripts/build_ffi.py
@@ -1306,6 +1306,7 @@ def build_ffi(local_wolfssl, features):
 
     if features["ML_DSA"]:
         cdef += """
+        static const int DILITHIUM_SEED_SZ;
         static const int WC_ML_DSA_44;
         static const int WC_ML_DSA_65;
         static const int WC_ML_DSA_87;

--- a/tests/test_mldsa.py
+++ b/tests/test_mldsa.py
@@ -203,3 +203,14 @@ if _lib.ML_DSA_ENABLED:
         with pytest.raises(ValueError):
             _ = mldsa_priv.sign_with_seed(message, signature_seed[:-1], ctx=bytes(1000))
 
+    def test_make_key_from_seed(mldsa_type):
+        seed = bytes(MlDsaPrivate.ML_DSA_KEYGEN_SEED_LENGTH)
+        assert MlDsaPrivate.make_key_from_seed(mldsa_type, seed)
+
+    @pytest.mark.parametrize(
+        "seed_length", [MlDsaPrivate.ML_DSA_KEYGEN_SEED_LENGTH - 1, MlDsaPrivate.ML_DSA_KEYGEN_SEED_LENGTH + 1]
+    )
+    def test_make_key_from_seed_bad_length(mldsa_type, seed_length):
+        seed = bytes(seed_length)
+        with pytest.raises(ValueError):
+            MlDsaPrivate.make_key_from_seed(mldsa_type, seed)

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -2139,6 +2139,7 @@ if _lib.ML_DSA_ENABLED:
 
     class _MlDsaBase:
         INVALID_DEVID = _lib.INVALID_DEVID
+        ML_DSA_KEYGEN_SEED_LENGTH = _lib.DILITHIUM_SEED_SZ
 
         def __init__(self, mldsa_type):
             self._init_done = False
@@ -2300,9 +2301,9 @@ if _lib.ML_DSA_ENABLED:
                 raise TypeError(
                     "seed must support the buffer protocol, such as `bytes` or `bytearray`"
                 ) from exception
-            if len(seed_view) != ML_DSA_KEYGEN_SEED_LENGTH:
+            if len(seed_view) != cls.ML_DSA_KEYGEN_SEED_LENGTH:
                 raise ValueError(
-                    f"Seed for generating ML-DSA key must be {ML_DSA_KEYGEN_SEED_LENGTH} bytes"
+                    f"Seed for generating ML-DSA key must be {cls.ML_DSA_KEYGEN_SEED_LENGTH} bytes"
                 )
 
             ret = _lib.wc_dilithium_make_key_from_seed(mldsa_priv.native_object,


### PR DESCRIPTION
The class method `make_key_from_seed()` of `MlDsaPrivate` uses the undefined variable `ML_DSA_KEYGEN_SEED_LENGTH`.
This patch adds this variable and adds a unit test for the class method.