### PR TITLE
Raise specialized WolfCryptApiError for failed API calls.

### DIFF
--- a/wolfcrypt/__init__.py
+++ b/wolfcrypt/__init__.py
@@ -46,15 +46,14 @@ top_level_py = os.path.basename(sys.argv[0])
 if top_level_py not in ["setup.py", "build_ffi.py"]:
     from wolfcrypt._ffi import ffi as _ffi
     from wolfcrypt._ffi import lib as _lib
-    from wolfcrypt.exceptions import WolfCryptError
+    from wolfcrypt.exceptions import WolfCryptApiError
 
     if hasattr(_lib, 'WC_RNG_SEED_CB_ENABLED'):
         if _lib.WC_RNG_SEED_CB_ENABLED:
             ret = _lib.wc_SetSeed_Cb(_ffi.addressof(_lib, "wc_GenerateSeed"))
             if ret < 0:
-                raise WolfCryptError("wc_SetSeed_Cb failed (%d)" % ret)
+                raise WolfCryptApiError("wc_SetSeed_Cb failed", ret)
     if _lib.FIPS_ENABLED and _lib.FIPS_VERSION >= 5:
         ret = _lib.wolfCrypt_SetPrivateKeyReadEnable_fips(1, _lib.WC_KEYTYPE_ALL)
         if ret < 0:
-            raise WolfCryptError("wolfCrypt_SetPrivateKeyReadEnable_fips failed"
-                " (%d)" % ret)
+            raise WolfCryptApiError("wolfCrypt_SetPrivateKeyReadEnable_fips failed", ret)

--- a/wolfcrypt/asn.py
+++ b/wolfcrypt/asn.py
@@ -24,7 +24,7 @@ import hmac as _hmac
 
 from wolfcrypt._ffi import ffi as _ffi
 from wolfcrypt._ffi import lib as _lib
-from wolfcrypt.exceptions import WolfCryptError
+from wolfcrypt.exceptions import WolfCryptError, WolfCryptApiError
 
 if _lib.SHA_ENABLED:
     from wolfcrypt.hashes import Sha
@@ -41,8 +41,7 @@ if _lib.ASN_ENABLED:
         ret = _lib.wc_PemToDer(pem, len(pem), pem_type, der, _ffi.NULL,
                                _ffi.NULL, _ffi.NULL)
         if ret != 0:
-            err = "Error converting from PEM to DER. ({})".format(ret)
-            raise WolfCryptError(err)
+            raise WolfCryptApiError("Error converting from PEM to DER.", ret)
 
         try:
             result = _ffi.buffer(der[0][0].buffer, der[0][0].length)[:]
@@ -54,15 +53,13 @@ if _lib.ASN_ENABLED:
         pem_length = _lib.wc_DerToPemEx(der, len(der), _ffi.NULL, 0, _ffi.NULL,
                                         pem_type)
         if pem_length <= 0:
-            err = "Error getting required PEM buffer length. ({})".format(pem_length)
-            raise WolfCryptError(err)
+            raise WolfCryptApiError("Error getting required PEM buffer length.", pem_length)
 
         pem = _ffi.new("byte[%d]" % pem_length)
         pem_length = _lib.wc_DerToPemEx(der, len(der), pem, pem_length,
                                         _ffi.NULL, pem_type)
         if pem_length <= 0:
-            err = "Error converting from DER to PEM. ({})".format(pem_length)
-            raise WolfCryptError(err)
+            raise WolfCryptApiError("Error converting from DER to PEM.", pem_length)
 
         return _ffi.buffer(pem, pem_length)[:]
 
@@ -76,8 +73,7 @@ if _lib.ASN_ENABLED:
         elif _lib.SHA512_ENABLED and hash_cls == Sha512:
             return _lib.SHA512h
         else:
-            err = "Unknown hash class {}.".format(hash_cls.__name__)
-            raise WolfCryptError(err)
+            raise WolfCryptError(f"Unknown hash class {hash_cls.__name__}")
 
     def make_signature(data, hash_cls, key=None):
         hash_obj = hash_cls()
@@ -89,8 +85,7 @@ if _lib.ASN_ENABLED:
         plaintext_len = _lib.wc_EncodeSignature(plaintext_sig, digest,
                                                 len(digest), hash_oid)
         if plaintext_len == 0:
-            err = "Error calling wc_EncodeSignature. ({})".format(plaintext_len)
-            raise WolfCryptError(err)
+            raise WolfCryptError(f"Error calling wc_EncodeSignature. ({plaintext_len})")
 
         plaintext_sig = _ffi.buffer(plaintext_sig, plaintext_len)[:]
         if key:

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -29,8 +29,7 @@ from wolfcrypt.random import Random
 from wolfcrypt.asn import pem_to_der
 from wolfcrypt.hashes import hash_type_to_cls
 
-from wolfcrypt.exceptions import WolfCryptError
-
+from wolfcrypt.exceptions import WolfCryptError, WolfCryptApiError
 
 # key direction flags
 _ENCRYPTION = 0
@@ -196,12 +195,12 @@ class _Cipher:
             ret = self._set_key(_ENCRYPTION)
             if ret < 0:  # pragma: no cover
                 self._enc = None
-                raise WolfCryptError("Invalid key error (%d)" % ret)
+                raise WolfCryptApiError("Invalid key error", ret)
 
         result = _ffi.new("byte[%d]" % len(string))
         ret = self._encrypt(result, string)
         if ret < 0:  # pragma: no cover
-            raise WolfCryptError("Encryption error (%d)" % ret)
+            raise WolfCryptApiError("Encryption error", ret)
 
         return _ffi.buffer(result)[:]
 
@@ -229,12 +228,12 @@ class _Cipher:
             ret = self._set_key(_DECRYPTION)
             if ret < 0:  # pragma: no cover
                 self._dec = None
-                raise WolfCryptError("Invalid key error (%d)" % ret)
+                raise WolfCryptApiError("Invalid key error", ret)
 
         result = _ffi.new("byte[%d]" % len(string))
         ret = self._decrypt(result, string)
         if ret < 0:  # pragma: no cover
-            raise WolfCryptError("Decryption error (%d)" % ret)
+            raise WolfCryptApiError("Decryption error", ret)
 
         return _ffi.buffer(result)[:]
 
@@ -318,7 +317,7 @@ if _lib.AES_SIV_ENABLED:
                 associated_data, len(associated_data), nonce, len(nonce),
                 plaintext, len(plaintext), siv, ciphertext)
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("AES-SIV encryption error (%d)" % ret)
+                raise WolfCryptApiError("AES-SIV encryption error", ret)
             return _ffi.buffer(siv)[:], _ffi.buffer(ciphertext)[:]
 
         def decrypt(self, associated_data, nonce, siv, ciphertext):
@@ -343,11 +342,11 @@ if _lib.AES_SIV_ENABLED:
                                  (AesSiv.block_size, len(siv)))
             ciphertext = t2b(ciphertext)
             plaintext = _ffi.new("byte[%d]" % len(ciphertext))
-            ref = _lib.wc_AesSivDecrypt_ex(self._key, len(self._key),
+            ret = _lib.wc_AesSivDecrypt_ex(self._key, len(self._key),
                 associated_data, len(associated_data), nonce, len(nonce),
                 ciphertext, len(ciphertext), siv, plaintext)
-            if ref < 0:
-                raise WolfCryptError("AES-SIV decryption error (%d)" % ref)
+            if ret < 0:
+                raise WolfCryptApiError("AES-SIV decryption error", ret)
             return _ffi.buffer(plaintext)[:]
 
         @staticmethod
@@ -420,11 +419,11 @@ if _lib.AESGCM_STREAM_ENABLED:
             self._native_object = _ffi.new(self._native_type)
             ret = _lib.wc_AesInit(self._native_object, _ffi.NULL, -2)
             if ret < 0:
-                raise WolfCryptError("AES init error (%d)" % ret)
+                raise WolfCryptApiError("AES init error", ret)
             self._init_done = True
             ret = _lib.wc_AesGcmInit(self._native_object, key, len(key), IV, len(IV))
             if ret < 0:
-                raise WolfCryptError("Init error (%d)" % ret)
+                raise WolfCryptApiError("Init error", ret)
 
         def __del__(self):
             if getattr(self, '_init_done', False):
@@ -456,7 +455,7 @@ if _lib.AESGCM_STREAM_ENABLED:
             buf = _ffi.new("byte[%d]" % (len(data)))
             ret = _lib.wc_AesGcmEncryptUpdate(self._native_object, buf, data, len(data), aad, len(aad))
             if ret < 0:
-                raise WolfCryptError("Encryption error (%d)" % ret)
+                raise WolfCryptApiError("Encryption error", ret)
             return bytes(buf)
 
         def decrypt(self, data):
@@ -473,7 +472,7 @@ if _lib.AESGCM_STREAM_ENABLED:
             buf = _ffi.new("byte[%d]" % (len(data)))
             ret = _lib.wc_AesGcmDecryptUpdate(self._native_object, buf, data, len(data), aad, len(aad))
             if ret < 0:
-                raise WolfCryptError("Decryption error (%d)" % ret)
+                raise WolfCryptApiError("Decryption error", ret)
             return bytes(buf)
 
         def final(self, authTag=None):
@@ -488,7 +487,7 @@ if _lib.AESGCM_STREAM_ENABLED:
                 authTag = _ffi.new("byte[%d]" % self._tag_bytes)
                 ret = _lib.wc_AesGcmEncryptFinal(self._native_object, authTag, self._tag_bytes)
                 if ret < 0:
-                    raise WolfCryptError("Encryption error (%d)" % ret)
+                    raise WolfCryptApiError("Encryption error", ret)
                 return _ffi.buffer(authTag)[:]
             else:
                 if authTag is None:
@@ -496,7 +495,7 @@ if _lib.AESGCM_STREAM_ENABLED:
                 authTag = t2b(authTag)
                 ret = _lib.wc_AesGcmDecryptFinal(self._native_object, authTag, len(authTag))
                 if ret < 0:
-                    raise WolfCryptError("Decryption error (%d)" % ret)
+                    raise WolfCryptApiError("Decryption error", ret)
 
 
 
@@ -563,7 +562,7 @@ if _lib.CHACHA_ENABLED:
             self._IV_counter = counter
             ret = self._set_key(0)
             if ret < 0:
-                raise WolfCryptError("ChaCha set_iv error (%d)" % ret)
+                raise WolfCryptApiError("ChaCha set_iv error", ret)
 
 if _lib.CHACHA20_POLY1305_ENABLED:
     class ChaCha20Poly1305:
@@ -607,7 +606,7 @@ if _lib.CHACHA20_POLY1305_ENABLED:
                 authTag
             )
             if ret < 0:
-                raise WolfCryptError("Encryption error (%d)" % ret)
+                raise WolfCryptApiError("Encryption error", ret)
             return bytes(ciphertext), bytes(authTag)
 
         def decrypt(self, aad, iv, authTag, ciphertext):
@@ -638,7 +637,7 @@ if _lib.CHACHA20_POLY1305_ENABLED:
                 plaintext
             )
             if ret < 0:
-                raise WolfCryptError("Decryption error (%d)" % ret)
+                raise WolfCryptApiError("Decryption error", ret)
             return bytes(plaintext)
 
 if _lib.DES3_ENABLED:
@@ -688,14 +687,14 @@ if _lib.RSA_ENABLED:
             self.native_object = _ffi.new("RsaKey *")
             ret = _lib.wc_InitRsaKey(self.native_object, _ffi.NULL)
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Invalid key error (%d)" % ret)
+                raise WolfCryptApiError("Invalid key error", ret)
 
             self._random = Random()
             if _lib.RSA_BLINDING_ENABLED:
                 ret = _lib.wc_RsaSetRNG(self.native_object,
                         self._random.native_object)
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("Key initialization error (%d)" % ret)
+                    raise WolfCryptApiError("Key initialization error", ret)
 
         # making sure _lib.wc_FreeRsaKey outlives RsaKey instances
         _delete = _lib.wc_FreeRsaKey
@@ -737,13 +736,12 @@ if _lib.RSA_ENABLED:
             ret = _lib.wc_RsaPublicKeyDecode(key, idx,
                     self.native_object, len(key))
             if ret < 0:
-                raise WolfCryptError("Invalid key error (%d)" % ret)
+                raise WolfCryptApiError("Invalid key error", ret)
 
             self.output_size = _lib.wc_RsaEncryptSize(self.native_object)
             self.size = len(key)
             if self.output_size <= 0:  # pragma: no cover
-                raise WolfCryptError("Invalid key error (%d)" %
-                        self.output_size)
+                raise WolfCryptApiError("Invalid key error", self.output_size)
 
         if _lib.ASN_ENABLED:
             @classmethod
@@ -770,7 +768,7 @@ if _lib.RSA_ENABLED:
                                            self._random.native_object)
 
             if ret != self.output_size:  # pragma: no cover
-                raise WolfCryptError("Encryption error (%d)" % ret)
+                raise WolfCryptApiError("Encryption error", ret)
 
             return _ffi.buffer(ciphertext)[:]
 
@@ -790,7 +788,7 @@ if _lib.RSA_ENABLED:
                                               self._mgf, label, len(label))
 
             if ret != self.output_size:  # pragma: no cover
-                raise WolfCryptError("Encryption error (%d)" % ret)
+                raise WolfCryptApiError("Encryption error", ret)
 
             return _ffi.buffer(ciphertext)[:]
 
@@ -811,7 +809,7 @@ if _lib.RSA_ENABLED:
                                         self.native_object)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Verify error (%d)" % ret)
+                raise WolfCryptApiError("Verify error", ret)
 
             return _ffi.buffer(plaintext, ret)[:]
 
@@ -845,14 +843,14 @@ if _lib.RSA_ENABLED:
                                             self.native_object)
 
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("Verify error (%d)" % ret)
+                    raise WolfCryptApiError("Verify error", ret)
 
                 digest = hash_cls.new(plaintext).digest()
                 ret = _lib.wc_RsaPSS_CheckPadding(digest, len(digest),
                                                   verify, ret, self._hash_type)
 
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("PSS padding check error (%d)" % ret)
+                    raise WolfCryptApiError("PSS padding check error", ret)
 
                 return ret == 0
 
@@ -871,12 +869,12 @@ if _lib.RSA_ENABLED:
                 ret = _lib.wc_MakeRsaKey(rsa.native_object, size, 65537,
                         rng.native_object)
                 if ret < 0:
-                    raise WolfCryptError("Key generation error (%d)" % ret)
+                    raise WolfCryptApiError("Key generation error", ret)
 
                 rsa.output_size = _lib.wc_RsaEncryptSize(rsa.native_object)
                 rsa.size = size
                 if rsa.output_size <= 0:  # pragma: no cover
-                    raise WolfCryptError("Invalid key size error (%d)" % ret)
+                    raise WolfCryptApiError("Invalid key size error", ret)
 
                 # Retain RNG reference defensively.
                 rsa._rng = rng
@@ -898,18 +896,17 @@ if _lib.RSA_ENABLED:
                     idx[0] = 0
                     ret = _lib.wc_GetPkcs8TraditionalOffset(key, idx, len(key))
                     if ret < 0:
-                        raise WolfCryptError("Invalid key error (%d)" % ret)
+                        raise WolfCryptApiError("Invalid key error", ret)
 
                     ret = _lib.wc_RsaPrivateKeyDecode(key, idx,
                                               self.native_object, len(key))
                     if ret < 0:
-                        raise WolfCryptError("Invalid key error (%d)" % ret)
+                        raise WolfCryptApiError("Invalid key error", ret)
 
                 self.size = len(key)
                 self.output_size = _lib.wc_RsaEncryptSize(self.native_object)
                 if self.output_size <= 0:  # pragma: no cover
-                    raise WolfCryptError("Invalid key size error (%d)" %
-                            self.output_size)
+                    raise WolfCryptApiError("Invalid key size error", self.output_size)
 
         if _lib.ASN_ENABLED:
             @classmethod
@@ -930,13 +927,12 @@ if _lib.RSA_ENABLED:
 
                 ret = _lib.wc_RsaKeyToDer(self.native_object, priv, self.size)
                 if ret <= 0:  # pragma: no cover
-                    raise WolfCryptError("Private RSA key error (%d)" % ret)
+                    raise WolfCryptApiError("Private RSA key error", ret)
                 privlen = ret
                 ret = _lib.wc_RsaKeyToPublicDer(self.native_object, pub,
                         self.size)
                 if ret <= 0:  # pragma: no cover
-                    raise WolfCryptError("Public RSA key encode error (%d)" %
-                            ret)
+                    raise WolfCryptApiError("Public RSA key encode error", ret)
                 publen = ret
                 return _ffi.buffer(priv, privlen)[:], _ffi.buffer(pub,
                         publen)[:]
@@ -958,7 +954,7 @@ if _lib.RSA_ENABLED:
                                             self.native_object)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Decryption error (%d)" % ret)
+                raise WolfCryptApiError("Decryption error", ret)
 
             return _ffi.buffer(plaintext, ret)[:]
 
@@ -985,7 +981,7 @@ if _lib.RSA_ENABLED:
                                                self._mgf, label, len(label))
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Decryption error (%d)" % ret)
+                raise WolfCryptApiError("Decryption error", ret)
 
             return _ffi.buffer(plaintext, ret)[:]
 
@@ -1007,7 +1003,7 @@ if _lib.RSA_ENABLED:
                                       self._random.native_object)
 
             if ret != self.output_size:  # pragma: no cover
-                raise WolfCryptError("Signature error (%d)" % ret)
+                raise WolfCryptApiError("Signature error", ret)
 
             return _ffi.buffer(signature, self.output_size)[:]
 
@@ -1043,7 +1039,7 @@ if _lib.RSA_ENABLED:
                                           self._random.native_object)
 
                 if ret != self.output_size:  # pragma: no cover
-                    raise WolfCryptError("Signature error (%d)" % ret)
+                    raise WolfCryptApiError("Signature error", ret)
 
                 return _ffi.buffer(signature, self.output_size)[:]
 
@@ -1054,7 +1050,7 @@ if _lib.ECC_ENABLED:
             self.native_object = _ffi.new("ecc_key *")
             ret = _lib.wc_ecc_init(self.native_object)
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Invalid key error (%d)" % ret)
+                raise WolfCryptApiError("Invalid key error", ret)
 
         # making sure _lib.wc_ecc_free outlives ecc_key instances
         _delete = _lib.wc_ecc_free
@@ -1091,7 +1087,7 @@ if _lib.ECC_ENABLED:
             ret = _lib.wc_EccPublicKeyDecode(key, idx,
                                              self.native_object, len(key))
             if ret < 0:
-                raise WolfCryptError("Key decode error (%d)" % ret)
+                raise WolfCryptApiError("Key decode error", ret)
             if self.size <= 0:  # pragma: no cover
                 raise WolfCryptError("Key decode error (%d)" % self.size)
             if self.max_signature_size <= 0:  # pragma: no cover
@@ -1105,7 +1101,7 @@ if _lib.ECC_ENABLED:
             ret = _lib.wc_ecc_import_unsigned(self.native_object, qx, qy,
                     _ffi.NULL, curve_id)
             if ret != 0:
-                raise WolfCryptError("Key decode error (%d)" % ret)
+                raise WolfCryptApiError("Key decode error", ret)
 
         def encode_key(self, with_curve=True):
             """
@@ -1118,7 +1114,7 @@ if _lib.ECC_ENABLED:
             ret = _lib.wc_EccPublicKeyToDer(self.native_object, key, len(key),
                                             with_curve)
             if ret <= 0:  # pragma: no cover
-                raise WolfCryptError("Key encode error (%d)" % ret)
+                raise WolfCryptApiError("Key encode error", ret)
 
             return _ffi.buffer(key, ret)[:]
 
@@ -1138,7 +1134,7 @@ if _lib.ECC_ENABLED:
             ret = _lib.wc_ecc_export_public_raw(self.native_object, Qx,
                     qx_size, Qy, qy_size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Key encode error (%d)" % ret)
+                raise WolfCryptApiError("Key encode error", ret)
 
             return _ffi.buffer(Qx, qx_size[0])[:], _ffi.buffer(Qy,
                     qy_size[0])[:]
@@ -1149,7 +1145,7 @@ if _lib.ECC_ENABLED:
             """
             ret = _lib.wc_ecc_import_x963(x963, len(x963), self.native_object)
             if ret != 0:
-                raise WolfCryptError("x963 import error (%d)" % ret)
+                raise WolfCryptApiError("x963 import error", ret)
 
         def export_x963(self):
             """
@@ -1163,7 +1159,7 @@ if _lib.ECC_ENABLED:
 
             ret = _lib.wc_ecc_export_x963(self.native_object, x963, x963_size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("x963 export error (%d)" % ret)
+                raise WolfCryptApiError("x963 export error", ret)
 
             return _ffi.buffer(x963, x963_size[0])[:]
 
@@ -1181,7 +1177,7 @@ if _lib.ECC_ENABLED:
                                           status, self.native_object)
 
             if ret < 0:
-                raise WolfCryptError("Verify error (%d)" % ret)
+                raise WolfCryptApiError("Verify error", ret)
 
             return status[0] == 1
 
@@ -1200,27 +1196,27 @@ if _lib.ECC_ENABLED:
                 mpS = _ffi.new("mp_int[1]")
                 ret = _lib.mp_init(mpR)
                 if ret != 0:  # pragma: no cover
-                    raise WolfCryptError("wolfCrypt error (%d)" % ret)
+                    raise WolfCryptApiError("wolfCrypt error", ret)
                 ret = _lib.mp_init(mpS)
                 if ret != 0:  # pragma: no cover
                     _lib.mp_clear(mpR)
-                    raise WolfCryptError("wolfCrypt error (%d)" % ret)
+                    raise WolfCryptApiError("wolfCrypt error", ret)
 
                 try:
                     ret = _lib.mp_read_unsigned_bin(mpR, R, len(R))
                     if ret != 0:  # pragma: no cover
-                        raise WolfCryptError("wolfCrypt error (%d)" % ret)
+                        raise WolfCryptApiError("wolfCrypt error", ret)
 
                     ret = _lib.mp_read_unsigned_bin(mpS, S, len(S))
                     if ret != 0:  # pragma: no cover
-                        raise WolfCryptError("wolfCrypt error (%d)" % ret)
+                        raise WolfCryptApiError("wolfCrypt error", ret)
 
                     ret = _lib.wc_ecc_verify_hash_ex(mpR, mpS,
                                                   data, len(data),
                                                   status, self.native_object)
 
                     if ret < 0:
-                        raise WolfCryptError("Verify error (%d)" % ret)
+                        raise WolfCryptApiError("Verify error", ret)
 
                     return status[0] == 1
                 finally:
@@ -1241,13 +1237,13 @@ if _lib.ECC_ENABLED:
             ret = _lib.wc_ecc_make_key(rng.native_object, size,
                     ecc.native_object)
             if ret < 0:
-                raise WolfCryptError("Key generation error (%d)" % ret)
+                raise WolfCryptApiError("Key generation error", ret)
 
             if _lib.ECC_TIMING_RESISTANCE_ENABLED and (not _lib.FIPS_ENABLED or
                _lib.FIPS_VERSION > 2):
                 ret = _lib.wc_ecc_set_rng(ecc.native_object, rng.native_object)
                 if ret < 0:
-                    raise WolfCryptError("Error setting ECC RNG (%d)" % ret)
+                    raise WolfCryptApiError("Error setting ECC RNG", ret)
 
             # Retain the RNG so it outlives the ECC key. Even outside the
             # timing-resistance path, wolfSSL internals may retain a pointer
@@ -1268,9 +1264,9 @@ if _lib.ECC_ENABLED:
             ret = _lib.wc_EccPrivateKeyDecode(key, idx,
                                               self.native_object, len(key))
             if ret < 0:
-                raise WolfCryptError("Key decode error (%d)" % ret)
+                raise WolfCryptApiError("Key decode error", ret)
             if self.size <= 0:  # pragma: no cover
-                raise WolfCryptError("Key decode error (%d)" % self.size)
+                raise WolfCryptApiError("Key decode error", self.size)
             if self.max_signature_size <= 0:  # pragma: no cover
                 raise WolfCryptError(
                     "Key decode error (%d)" % self.max_signature_size)
@@ -1283,7 +1279,7 @@ if _lib.ECC_ENABLED:
             ret = _lib.wc_ecc_import_unsigned(self.native_object, qx, qy, d,
                     curve_id)
             if ret != 0:
-                raise WolfCryptError("Key decode error (%d)" % ret)
+                raise WolfCryptApiError("Key decode error", ret)
 
         def encode_key(self):
             """
@@ -1295,7 +1291,7 @@ if _lib.ECC_ENABLED:
 
             ret = _lib.wc_EccKeyToDer(self.native_object, key, len(key))
             if ret <= 0:  # pragma: no cover
-                raise WolfCryptError("Key encode error (%d)" % ret)
+                raise WolfCryptApiError("Key encode error", ret)
 
             return _ffi.buffer(key, ret)[:]
 
@@ -1318,7 +1314,7 @@ if _lib.ECC_ENABLED:
             ret = _lib.wc_ecc_export_private_raw(self.native_object, Qx,
                     qx_size, Qy, qy_size, d, d_size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Key encode error (%d)" % ret)
+                raise WolfCryptApiError("Key encode error", ret)
 
             return _ffi.buffer(Qx, qx_size[0])[:], _ffi.buffer(Qy,
                     qy_size[0])[:], _ffi.buffer(d, d_size[0])[:]
@@ -1339,7 +1335,7 @@ if _lib.ECC_ENABLED:
                                             shared_secret, secret_size)
 
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Shared secret error (%d)" % ret)
+                raise WolfCryptApiError("Shared secret error", ret)
 
             return _ffi.buffer(shared_secret, secret_size[0])[:]
 
@@ -1363,7 +1359,7 @@ if _lib.ECC_ENABLED:
                                         self.native_object)
 
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Signature error (%d)" % ret)
+                raise WolfCryptApiError("Signature error", ret)
 
             return _ffi.buffer(signature, signature_size[0])[:]
 
@@ -1385,11 +1381,11 @@ if _lib.ECC_ENABLED:
 
                 ret = _lib.mp_init(R)
                 if ret != 0:  # pragma: no cover
-                    raise WolfCryptError("wolfCrypt error (%d)" % ret)
+                    raise WolfCryptApiError("wolfCrypt error", ret)
                 ret = _lib.mp_init(S)
                 if ret != 0:  # pragma: no cover
                     _lib.mp_clear(R)
-                    raise WolfCryptError("wolfCrypt error (%d)" % ret)
+                    raise WolfCryptApiError("wolfCrypt error", ret)
 
                 try:
                     ret = _lib.wc_ecc_sign_hash_ex(plaintext, len(plaintext),
@@ -1397,15 +1393,15 @@ if _lib.ECC_ENABLED:
                                                 self.native_object,
                                                 R, S)
                     if ret != 0:  # pragma: no cover
-                        raise WolfCryptError("Signature error (%d)" % ret)
+                        raise WolfCryptApiError("Signature error", ret)
 
                     ret = _lib.mp_to_unsigned_bin_len(R, R_bin, self.size)
                     if ret != 0:  # pragma: no cover
-                        raise WolfCryptError("wolfCrypt error (%d)" % ret)
+                        raise WolfCryptApiError("wolfCrypt error", ret)
 
                     ret = _lib.mp_to_unsigned_bin_len(S, S_bin, self.size)
                     if ret != 0:  # pragma: no cover
-                        raise WolfCryptError("wolfCrypt error (%d)" % ret)
+                        raise WolfCryptApiError("wolfCrypt error", ret)
 
                     return _ffi.buffer(R_bin, self.size)[:], _ffi.buffer(S_bin,
                             self.size)[:]
@@ -1420,7 +1416,7 @@ if _lib.ED25519_ENABLED:
             self.native_object = _ffi.new("ed25519_key *")
             ret = _lib.wc_ed25519_init(self.native_object)
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Invalid key error (%d)" % ret)
+                raise WolfCryptApiError("Invalid key error", ret)
 
         # making sure _lib.wc_ed25519_free outlives ed25519_key instances
         _delete = _lib.wc_ed25519_free
@@ -1458,7 +1454,7 @@ if _lib.ED25519_ENABLED:
             ret = _lib.wc_ed25519_import_public(key, len(key),
                     self.native_object)
             if ret < 0:
-                raise WolfCryptError("Key decode error (%d)" % ret)
+                raise WolfCryptApiError("Key decode error", ret)
             if self.size <= 0:  # pragma: no cover
                 raise WolfCryptError("Key decode error (%d)" % self.size)
             if self.max_signature_size <= 0:  # pragma: no cover
@@ -1478,7 +1474,7 @@ if _lib.ED25519_ENABLED:
 
             ret = _lib.wc_ed25519_export_public(self.native_object, key, size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Key encode error (%d)" % ret)
+                raise WolfCryptApiError("Key encode error", ret)
 
             return _ffi.buffer(key, size[0])[:]
 
@@ -1496,7 +1492,7 @@ if _lib.ED25519_ENABLED:
                                           status, self.native_object)
 
             if ret < 0:
-                raise WolfCryptError("Verify error (%d)" % ret)
+                raise WolfCryptApiError("Verify error", ret)
 
             return status[0] == 1
 
@@ -1523,7 +1519,7 @@ if _lib.ED25519_ENABLED:
             ret = _lib.wc_ed25519_make_key(rng.native_object, size,
                     ed25519.native_object)
             if ret < 0:
-                raise WolfCryptError("Key generation error (%d)" % ret)
+                raise WolfCryptApiError("Key generation error", ret)
 
             # Retain RNG reference defensively; wolfSSL may retain a pointer
             # internally on some builds.
@@ -1546,21 +1542,21 @@ if _lib.ED25519_ENABLED:
                 ret = _lib.wc_ed25519_import_private_key(key, len(key), pub,
                         len(pub), self.native_object)
                 if ret < 0:
-                    raise WolfCryptError("Key decode error (%d)" % ret)
+                    raise WolfCryptApiError("Key decode error", ret)
             else:
                 ret = _lib.wc_ed25519_import_private_only(key, len(key),
                         self.native_object)
                 if ret < 0:
-                    raise WolfCryptError("Key decode error (%d)" % ret)
+                    raise WolfCryptApiError("Key decode error", ret)
                 pubkey = _ffi.new("byte[%d]" % (self.size * 4))
                 ret = _lib.wc_ed25519_make_public(self.native_object, pubkey,
                         self.size)
                 if ret < 0:
-                    raise WolfCryptError("Public key generate error (%d)" % ret)
+                    raise WolfCryptApiError("Public key generate error", ret)
                 ret = _lib.wc_ed25519_import_public(pubkey, self.size,
                         self.native_object)
                 if ret < 0:
-                    raise WolfCryptError("Public key import error (%d)" % ret)
+                    raise WolfCryptApiError("Public key import error", ret)
 
             if self.size <= 0:  # pragma: no cover
                 raise WolfCryptError("Key decode error (%d)" % self.size)
@@ -1585,11 +1581,11 @@ if _lib.ED25519_ENABLED:
             ret = _lib.wc_ed25519_export_private_only(self.native_object,
                     key, priv_size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Private key encode error (%d)" % ret)
+                raise WolfCryptApiError("Private key encode error", ret)
             ret = _lib.wc_ed25519_export_public(self.native_object, pubkey,
                     pub_size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Public key encode error (%d)" % ret)
+                raise WolfCryptApiError("Public key encode error", ret)
 
             return _ffi.buffer(key, priv_size[0])[:], _ffi.buffer(pubkey, pub_size[0])[:]
 
@@ -1610,7 +1606,7 @@ if _lib.ED25519_ENABLED:
                                         self.native_object)
 
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Signature error (%d)" % ret)
+                raise WolfCryptApiError("Signature error", ret)
 
             return _ffi.buffer(signature, signature_size[0])[:]
 
@@ -1620,7 +1616,7 @@ if _lib.ED448_ENABLED:
             self.native_object = _ffi.new("ed448_key *")
             ret = _lib.wc_ed448_init(self.native_object)
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Invalid key error (%d)" % ret)
+                raise WolfCryptApiError("Invalid key error", ret)
 
         # making sure _lib.wc_ed448_free outlives ed448_key instances
         _delete = _lib.wc_ed448_free
@@ -1658,7 +1654,7 @@ if _lib.ED448_ENABLED:
             ret = _lib.wc_ed448_import_public(key, len(key),
                     self.native_object)
             if ret < 0:
-                raise WolfCryptError("Key decode error (%d)" % ret)
+                raise WolfCryptApiError("Key decode error", ret)
             if self.size <= 0:  # pragma: no cover
                 raise WolfCryptError("Key decode error (%d)" % self.size)
             if self.max_signature_size <= 0:  # pragma: no cover
@@ -1678,7 +1674,7 @@ if _lib.ED448_ENABLED:
 
             ret = _lib.wc_ed448_export_public(self.native_object, key, size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Key encode error (%d)" % ret)
+                raise WolfCryptApiError("Key encode error", ret)
 
             return _ffi.buffer(key, size[0])[:]
 
@@ -1702,7 +1698,7 @@ if _lib.ED448_ENABLED:
                                           ctx_buf_len)
 
             if ret < 0:
-                raise WolfCryptError("Verify error (%d)" % ret)
+                raise WolfCryptApiError("Verify error", ret)
 
             return status[0] == 1
 
@@ -1729,7 +1725,7 @@ if _lib.ED448_ENABLED:
             ret = _lib.wc_ed448_make_key(rng.native_object, size,
                     ed448.native_object)
             if ret < 0:
-                raise WolfCryptError("Key generation error (%d)" % ret)
+                raise WolfCryptApiError("Key generation error", ret)
 
             # Retain RNG reference defensively; wolfSSL may retain a pointer
             # internally on some builds.
@@ -1752,21 +1748,21 @@ if _lib.ED448_ENABLED:
                 ret = _lib.wc_ed448_import_private_key(key, len(key), pub,
                         len(pub), self.native_object)
                 if ret < 0:
-                    raise WolfCryptError("Key decode error (%d)" % ret)
+                    raise WolfCryptApiError("Key decode error", ret)
             else:
                 ret = _lib.wc_ed448_import_private_only(key, len(key),
                         self.native_object)
                 if ret < 0:
-                    raise WolfCryptError("Key decode error (%d)" % ret)
+                    raise WolfCryptApiError("Key decode error", ret)
                 pubkey = _ffi.new("byte[%d]" % (self.size * 4))
                 ret = _lib.wc_ed448_make_public(self.native_object, pubkey,
                         self.size)
                 if ret < 0:
-                    raise WolfCryptError("Public key generate error (%d)" % ret)
+                    raise WolfCryptApiError("Public key generate error", ret)
                 ret = _lib.wc_ed448_import_public(pubkey, self.size,
                         self.native_object)
                 if ret < 0:
-                    raise WolfCryptError("Public key import error (%d)" % ret)
+                    raise WolfCryptApiError("Public key import error", ret)
 
             if self.size <= 0:  # pragma: no cover
                 raise WolfCryptError("Key decode error (%d)" % self.size)
@@ -1791,11 +1787,11 @@ if _lib.ED448_ENABLED:
             ret = _lib.wc_ed448_export_private_only(self.native_object,
                     key, priv_size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Private key encode error (%d)" % ret)
+                raise WolfCryptApiError("Private key encode error", ret)
             ret = _lib.wc_ed448_export_public(self.native_object, pubkey,
                     pub_size)
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Public key encode error (%d)" % ret)
+                raise WolfCryptApiError("Public key encode error", ret)
 
             return _ffi.buffer(key, priv_size[0])[:], _ffi.buffer(pubkey, pub_size[0])[:]
 
@@ -1822,7 +1818,7 @@ if _lib.ED448_ENABLED:
                                         ctx_buf_len)
 
             if ret != 0:  # pragma: no cover
-                raise WolfCryptError("Signature error (%d)" % ret)
+                raise WolfCryptApiError("Signature error", ret)
 
             return _ffi.buffer(signature, signature_size[0])[:]
 
@@ -1856,7 +1852,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_Init() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_Init() error", ret)
 
             self.init_done = True
 
@@ -1874,7 +1870,7 @@ if _lib.ML_KEM_ENABLED:
             ret = _lib.wc_KyberKey_CipherTextSize(self.native_object, len)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_CipherTextSize() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_CipherTextSize() error", ret)
 
             return len[0]
 
@@ -1888,7 +1884,7 @@ if _lib.ML_KEM_ENABLED:
             ret = _lib.wc_KyberKey_SharedSecretSize(self.native_object, len)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_SharedSecretSize() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_SharedSecretSize() error", ret)
 
             return len[0]
 
@@ -1898,7 +1894,7 @@ if _lib.ML_KEM_ENABLED:
             ret = _lib.wc_KyberKey_PublicKeySize(self.native_object, len)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_PublicKeySize() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_PublicKeySize() error", ret)
 
             return len[0]
 
@@ -1910,7 +1906,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_EncodePublicKey() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_EncodePublicKey() error", ret)
 
             return _ffi.buffer(pub_key, pub_key_size)[:]
 
@@ -1943,7 +1939,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_DecodePublicKey() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_DecodePublicKey() error", ret)
 
         def encapsulate(self, rng=None):
             """
@@ -1963,7 +1959,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_Encapsulate() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_Encapsulate() error", ret)
 
             return _ffi.buffer(ss, ss_size)[:], _ffi.buffer(ct, ct_size)[:]
 
@@ -1983,9 +1979,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError(
-                    "wc_KyberKey_EncapsulateWithRandom() error (%d)" % ret
-                )
+                raise WolfCryptApiError("wc_KyberKey_EncapsulateWithRandom() error", ret)
 
             return _ffi.buffer(ss, ss_size)[:], _ffi.buffer(ct, ct_size)[:]
 
@@ -2006,7 +2000,7 @@ if _lib.ML_KEM_ENABLED:
             ret = _lib.wc_KyberKey_MakeKey(mlkem_priv.native_object, rng.native_object)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_MakeKey() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_MakeKey() error", ret)
 
             # Retain RNG reference defensively.
             mlkem_priv._rng = rng
@@ -2029,7 +2023,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_MakeKeyWithRandom() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_MakeKeyWithRandom() error", ret)
 
             return mlkem_priv
 
@@ -2051,7 +2045,7 @@ if _lib.ML_KEM_ENABLED:
             ret = _lib.wc_KyberKey_PrivateKeySize(self.native_object, len)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_PrivateKeySize() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_PrivateKeySize() error", ret)
 
             return len[0]
 
@@ -2074,7 +2068,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_EncodePrivateKey() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_EncodePrivateKey() error", ret)
 
             return _ffi.buffer(priv_key, priv_key_size)[:]
 
@@ -2091,7 +2085,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_DecodePrivateKey() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_DecodePrivateKey() error", ret)
 
         def decapsulate(self, ct):
             """
@@ -2111,7 +2105,7 @@ if _lib.ML_KEM_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_KyberKey_Decapsulate() error (%d)" % ret)
+                raise WolfCryptApiError("wc_KyberKey_Decapsulate() error", ret)
 
             return _ffi.buffer(ss, ss_size)[:]
 
@@ -2148,14 +2142,14 @@ if _lib.ML_DSA_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_dilithium_init_ex() error (%d)" % ret)
+                raise WolfCryptApiError("wc_dilithium_init_ex() error", ret)
 
             self._init_done = True
 
             ret = _lib.wc_dilithium_set_level(self.native_object, mldsa_type)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_dilithium_set_level() error (%d)" % ret)
+                raise WolfCryptApiError("wc_dilithium_set_level() error", ret)
 
         def __del__(self):
             if self._init_done:
@@ -2167,7 +2161,7 @@ if _lib.ML_DSA_ENABLED:
             ret = _lib.wc_MlDsaKey_GetPubLen(self.native_object, size)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_MlDsaKey_GetPubLen() error (%d)" % ret)
+                raise WolfCryptApiError("wc_MlDsaKey_GetPubLen() error", ret)
 
             return size[0]
 
@@ -2181,7 +2175,7 @@ if _lib.ML_DSA_ENABLED:
             ret = _lib.wc_MlDsaKey_GetSigLen(self.native_object, size)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_MlDsaKey_GetSigLen() error (%d)" % ret)
+                raise WolfCryptApiError("wc_MlDsaKey_GetSigLen() error", ret)
 
             return size[0]
 
@@ -2194,7 +2188,7 @@ if _lib.ML_DSA_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_dilithium_import_public() error (%d)" % ret)
+                raise WolfCryptApiError("wc_dilithium_import_public() error", ret)
 
         def _encode_pub_key(self):
             in_size = self._pub_key_size
@@ -2204,7 +2198,7 @@ if _lib.ML_DSA_ENABLED:
             ret = _lib.wc_dilithium_export_public(self.native_object, pub_key, out_size)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_dilithium_export_public() error (%d)" % ret)
+                raise WolfCryptApiError("wc_dilithium_export_public() error", ret)
 
             if in_size != out_size[0]:
                 raise WolfCryptError(
@@ -2241,7 +2235,7 @@ if _lib.ML_DSA_ENABLED:
                     self.native_object,
                 )
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("wc_dilithium_verify_ctx_msg() error (%d)" % ret)
+                    raise WolfCryptApiError("wc_dilithium_verify_ctx_msg() error", ret)
             else:
                 ret = _lib.wc_dilithium_verify_msg(
                     _ffi.from_buffer(sig_bytestype),
@@ -2252,7 +2246,7 @@ if _lib.ML_DSA_ENABLED:
                     self.native_object,
                 )
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("wc_dilithium_verify_msg() error (%d)" % ret)
+                    raise WolfCryptApiError("wc_dilithium_verify_msg() error", ret)
 
             return res[0] == 1
 
@@ -2276,7 +2270,7 @@ if _lib.ML_DSA_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_dilithium_make_key() error (%d)" % ret)
+                raise WolfCryptApiError("wc_dilithium_make_key() error", ret)
 
             # Retain RNG reference defensively.
             mldsa_priv._rng = rng
@@ -2309,7 +2303,7 @@ if _lib.ML_DSA_ENABLED:
                     _ffi.from_buffer(seed_view))
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_dilithium_make_key_from_seed() error (%d)" % ret)
+                raise WolfCryptApiError("wc_dilithium_make_key_from_seed() error", ret)
 
             return mldsa_priv
 
@@ -2331,7 +2325,7 @@ if _lib.ML_DSA_ENABLED:
             ret = _lib.wc_MlDsaKey_GetPrivLen(self.native_object, size)
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_MlDsaKey_GetPrivLen() error (%d)" % ret)
+                raise WolfCryptApiError("wc_MlDsaKey_GetPrivLen() error", ret)
 
             return size[0] - self.pub_key_size
 
@@ -2356,7 +2350,7 @@ if _lib.ML_DSA_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_dilithium_export_private() error (%d)" % ret)
+                raise WolfCryptApiError("wc_dilithium_export_private() error", ret)
 
             if in_size != out_size[0]:
                 raise WolfCryptError(
@@ -2380,7 +2374,7 @@ if _lib.ML_DSA_ENABLED:
             )
 
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("wc_dilithium_import_private() error (%d)" % ret)
+                raise WolfCryptApiError("wc_dilithium_import_private() error", ret)
 
             if pub_key is not None:
                 self._decode_pub_key(pub_key)
@@ -2419,7 +2413,7 @@ if _lib.ML_DSA_ENABLED:
                     rng.native_object,
                 )
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("wc_dilithium_sign_ctx_msg() error (%d)" % ret)
+                    raise WolfCryptApiError("wc_dilithium_sign_ctx_msg() error", ret)
             else:
                 ret = _lib.wc_dilithium_sign_msg(
                     _ffi.from_buffer(msg_bytestype),
@@ -2430,7 +2424,7 @@ if _lib.ML_DSA_ENABLED:
                     rng.native_object,
                 )
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("wc_dilithium_sign_msg() error (%d)" % ret)
+                    raise WolfCryptApiError("wc_dilithium_sign_msg() error", ret)
             
             if in_size != out_size[0]:
                 raise WolfCryptError(
@@ -2485,7 +2479,7 @@ if _lib.ML_DSA_ENABLED:
                     _ffi.from_buffer(seed_view),
                 )
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("wc_dilithium_sign_ctx_msg_with_seed() error (%d)" % ret)
+                    raise WolfCryptApiError("wc_dilithium_sign_ctx_msg_with_seed() error", ret)
             else:
                 ret = _lib.wc_dilithium_sign_msg_with_seed(
                     _ffi.from_buffer(msg_bytestype),
@@ -2496,7 +2490,7 @@ if _lib.ML_DSA_ENABLED:
                     _ffi.from_buffer(seed_view),
                 )
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("wc_dilithium_sign_msg_with_seed() error (%d)" % ret)
+                    raise WolfCryptApiError("wc_dilithium_sign_msg_with_seed() error", ret)
 
 
             if in_size != out_size[0]:

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -873,8 +873,8 @@ if _lib.RSA_ENABLED:
 
                 rsa.output_size = _lib.wc_RsaEncryptSize(rsa.native_object)
                 rsa.size = size
-                if rsa.output_size <= 0:  # pragma: no cover
-                    raise WolfCryptApiError("Invalid key size error", ret)
+                if rsa.output_size < 0:  # pragma: no cover
+                    raise WolfCryptApiError("Invalid key size error", rsa.output_size)
 
                 # Retain RNG reference defensively.
                 rsa._rng = rng

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -1266,7 +1266,7 @@ if _lib.ECC_ENABLED:
             if ret < 0:
                 raise WolfCryptApiError("Key decode error", ret)
             if self.size <= 0:  # pragma: no cover
-                raise WolfCryptApiError("Key decode error", self.size)
+                raise WolfCryptError(f"Key decode error {self.size}")
             if self.max_signature_size <= 0:  # pragma: no cover
                 raise WolfCryptError(
                     "Key decode error (%d)" % self.max_signature_size)

--- a/wolfcrypt/exceptions.py
+++ b/wolfcrypt/exceptions.py
@@ -27,6 +27,27 @@ class WolfCryptError(Exception):
     pass
 
 
+class WolfCryptApiError(WolfCryptError):
+    """
+    WolfCrypt API error displaying the error code and error message if support is compiled in.
+    """
+    def __init__(self, message: str, err_code: int) -> None:
+        """
+        Create a WolfCryptApiError exception.
+
+        :param message: error message
+        :param err_code: WolfCrypt error code
+        """
+        err_string = error_string(err_code)
+
+        if err_string:
+            reason = f": {err_string}"
+        else:
+            reason = ""
+
+        super().__init__(f"{message} ({err_code}){reason}")
+
+
 def error_string(err_code: int) -> str:
     """
     Convert error code to error string.

--- a/wolfcrypt/hashes.py
+++ b/wolfcrypt/hashes.py
@@ -24,7 +24,7 @@ from wolfcrypt._ffi import ffi as _ffi
 from wolfcrypt._ffi import lib as _lib
 from wolfcrypt.utils import t2b, b2h
 
-from wolfcrypt.exceptions import WolfCryptError, error_string
+from wolfcrypt.exceptions import WolfCryptApiError
 
 
 class _Hash:
@@ -37,7 +37,7 @@ class _Hash:
         self._shallow_copy = False
         ret = self._init()
         if ret < 0:  # pragma: no cover
-            raise WolfCryptError("Hash init error (%d)" % ret)
+            raise WolfCryptApiError("Hash init error", ret)
 
         if string:
             self.update(string)
@@ -75,7 +75,7 @@ class _Hash:
                 delete = getattr(self, '_delete', None)
                 if delete:
                     delete(copy._native_object)  # pylint: disable=protected-access
-                raise WolfCryptError("Hash copy error (%d)" % ret)
+                raise WolfCryptApiError("Hash copy error", ret)
             copy._shallow_copy = False  # pylint: disable=protected-access
         else:
             _ffi.memmove(copy._native_object,  # pylint: disable=protected-access
@@ -96,7 +96,7 @@ class _Hash:
 
         ret = self._update(string)
         if ret < 0:  # pragma: no cover
-            raise WolfCryptError("Hash update error (%d)" % ret)
+            raise WolfCryptApiError("Hash update error", ret)
 
     def digest(self):
         """
@@ -119,13 +119,13 @@ class _Hash:
                 if copy_fn:
                     ret = copy_fn(self._native_object, obj)
                     if ret < 0:  # pragma: no cover
-                        raise WolfCryptError("Hash copy error (%d)" % ret)
+                        raise WolfCryptApiError("Hash copy error", ret)
                 else:
                     _ffi.memmove(obj, self._native_object, self._native_size)
 
                 ret = self._final(obj, result)
                 if ret < 0:  # pragma: no cover
-                    raise WolfCryptError("Hash finalize error (%d)" % ret)
+                    raise WolfCryptApiError("Hash finalize error", ret)
             finally:
                 # Only free when we did a deep copy; memmove'd temps share
                 # internal resources with self and must not be separately freed.
@@ -305,7 +305,7 @@ if _lib.SHA3_ENABLED:
             self._copy = self._SHA3_COPY.get(size)
             ret = self._init()
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Sha3 init error (%d)" % ret)
+                raise WolfCryptApiError("Sha3 init error", ret)
             if string:
                 self.update(string)
 
@@ -330,7 +330,7 @@ if _lib.SHA3_ENABLED:
                     # Free any partial allocation before raising.
                     if self._delete:
                         self._delete(c._native_object)
-                    raise WolfCryptError("Hash copy error (%d)" % ret)
+                    raise WolfCryptApiError("Hash copy error", ret)
                 c._shallow_copy = False
             else:
                 _ffi.memmove(c._native_object, self._native_object, self._native_size)
@@ -416,7 +416,7 @@ if _lib.HMAC_ENABLED:
             self._shallow_copy = False
             ret = self._init(self._type, key)
             if ret < 0:  # pragma: no cover
-                raise WolfCryptError("Hmac init error (%d)" % ret)
+                raise WolfCryptApiError("Hmac init error", ret)
 
             if string:
                 self.update(string)
@@ -433,8 +433,9 @@ if _lib.HMAC_ENABLED:
             return cls(key, string)
 
         def _init(self, hmac, key):
-            if _lib.wc_HmacInit(self._native_object, _ffi.NULL, -2) != 0:
-                raise WolfCryptError("wc_HmacInit error")
+            ret = _lib.wc_HmacInit(self._native_object, _ffi.NULL, -2)
+            if ret < 0:
+                raise WolfCryptApiError("wc_HmacInit error", ret)
             # If the key isn't set, don't call wc_HmacSetKey. This can happen,
             # for example, when the HMAC object is being copied. See the copy
             # function of _Hash.
@@ -442,8 +443,7 @@ if _lib.HMAC_ENABLED:
             if len(key) > 0:
                 ret = _lib.wc_HmacSetKey(self._native_object, hmac, key, len(key))
                 if ret < 0:
-                    err_str = error_string(ret)
-                    raise WolfCryptError("wc_HmacSetKey returned {}: {}".format(ret, err_str))
+                    raise WolfCryptApiError("wc_HmacSetKey error", ret)
             return ret
 
         def _update(self, data):

--- a/wolfcrypt/hkdf.py
+++ b/wolfcrypt/hkdf.py
@@ -23,7 +23,7 @@
 from wolfcrypt._ffi import ffi as _ffi
 from wolfcrypt._ffi import lib as _lib
 
-from wolfcrypt.exceptions import WolfCryptError
+from wolfcrypt.exceptions import WolfCryptApiError
 from wolfcrypt.utils import t2b
 
 
@@ -46,7 +46,7 @@ if _lib.HKDF_ENABLED:
         - bytes object containing the derived key of length `out_len`.
 
         Raises:
-        - WolfCryptError on failure.
+        - WolfCryptApiError on failure.
         - ValueError for invalid arguments.
         """
         in_key = t2b(in_key)
@@ -69,7 +69,7 @@ if _lib.HKDF_ENABLED:
             out_len,
         )
         if ret != 0:
-            raise WolfCryptError("HKDF error (%d)" % ret)
+            raise WolfCryptApiError("HKDF error", ret)
 
         return _ffi.buffer(out, out_len)[:]
 
@@ -86,7 +86,7 @@ if _lib.HKDF_ENABLED:
         Returns:
         - PRK as bytes (length == hash digest size).
 
-        Raises WolfCryptError on failure.
+        Raises WolfCryptApiError on failure.
         """
         salt = b"" if salt is None else t2b(salt)
         in_key = t2b(in_key)
@@ -96,7 +96,7 @@ if _lib.HKDF_ENABLED:
 
         ret = _lib.wc_HKDF_Extract(hash_cls._type, salt, len(salt), in_key, len(in_key), out)
         if ret != 0:
-            raise WolfCryptError("HKDF_Extract error (%d)" % ret)
+            raise WolfCryptApiError("HKDF_Extract error", ret)
 
         return _ffi.buffer(out, out_len)[:]
 
@@ -114,7 +114,7 @@ if _lib.HKDF_ENABLED:
         Returns:
         - OKM as bytes of length `out_len`.
 
-        Raises WolfCryptError on failure.
+        Raises WolfCryptApiError on failure.
         """
         prk = t2b(prk)
         info = b"" if info is None else t2b(info)
@@ -128,6 +128,6 @@ if _lib.HKDF_ENABLED:
             hash_cls._type, prk, len(prk), info, len(info), out, out_len
         )
         if ret != 0:
-            raise WolfCryptError("HKDF_Expand error (%d)" % ret)
+            raise WolfCryptApiError("HKDF_Expand error", ret)
 
         return _ffi.buffer(out, out_len)[:]

--- a/wolfcrypt/pwdbased.py
+++ b/wolfcrypt/pwdbased.py
@@ -23,7 +23,7 @@
 from wolfcrypt._ffi import ffi as _ffi
 from wolfcrypt._ffi import lib as _lib
 
-from wolfcrypt.exceptions import WolfCryptError
+from wolfcrypt.exceptions import WolfCryptApiError
 
 if _lib.PWDBASED_ENABLED:
     def PBKDF2(password, salt, iterations, key_length, hash_type):
@@ -38,6 +38,6 @@ if _lib.PWDBASED_ENABLED:
                              iterations, key_length, hash_type)
 
         if ret != 0:
-            raise WolfCryptError("PBKDF2 error (%d)" % ret)
+            raise WolfCryptApiError("PBKDF2 error", ret)
 
         return _ffi.buffer(key, key_length)[:]

--- a/wolfcrypt/random.py
+++ b/wolfcrypt/random.py
@@ -23,7 +23,7 @@
 from wolfcrypt._ffi import ffi as _ffi
 from wolfcrypt._ffi import lib as _lib
 
-from wolfcrypt.exceptions import WolfCryptError
+from wolfcrypt.exceptions import WolfCryptApiError
 
 
 class Random:
@@ -41,7 +41,7 @@ class Random:
         ret = _lib.wc_InitRngNonce_ex(self.native_object, nonce, nonce_size, _ffi.NULL, device_id)
         if ret < 0:  # pragma: no cover
             self.native_object = None
-            raise WolfCryptError("RNG init error (%d)" % ret)
+            raise WolfCryptApiError("RNG init error", ret)
 
     # making sure _lib.wc_FreeRng outlives WC_RNG instances
     _delete = _lib.wc_FreeRng
@@ -62,7 +62,7 @@ class Random:
 
         ret = _lib.wc_RNG_GenerateByte(self.native_object, result)
         if ret < 0:  # pragma: no cover
-            raise WolfCryptError("RNG generate byte error (%d)" % ret)
+            raise WolfCryptApiError("RNG generate byte error", ret)
 
         return _ffi.buffer(result, 1)[:]
 
@@ -74,6 +74,6 @@ class Random:
 
         ret = _lib.wc_RNG_GenerateBlock(self.native_object, result, length)
         if ret < 0:  # pragma: no cover
-            raise WolfCryptError("RNG generate block error (%d)" % ret)
+            raise WolfCryptApiError("RNG generate block error", ret)
 
         return _ffi.buffer(result, length)[:]


### PR DESCRIPTION
This exception takes the return value and converts that to a human-readable string (if error string support is compiled in.)

The specialized exception is derived from WolfCryptError meaning that existing users will not notice the difference except for the nicer description.