### PR TITLE
Remove unicode prefix.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,9 +51,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'wolfcrypt Python'
-copyright = u'2022, wolfSSL Inc. All rights reserved'
-author = u'wolfSSL'
+project = 'wolfcrypt Python'
+copyright = '2022, wolfSSL Inc. All rights reserved'
+author = 'wolfSSL'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -227,8 +227,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'wolfcrypt.tex', u'wolfcrypt Python Documentation',
-     u'wolfSSL', 'manual'),
+    (master_doc, 'wolfcrypt.tex', 'wolfcrypt Python Documentation',
+     'wolfSSL', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -257,7 +257,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'wolfcrypt', u'wolfcrypt Python Documentation',
+    (master_doc, 'wolfcrypt', 'wolfcrypt Python Documentation',
      [author], 1)
 ]
 
@@ -271,7 +271,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'wolfcrypt', u'wolfcrypt Python Documentation',
+    (master_doc, 'wolfcrypt', 'wolfcrypt Python Documentation',
      author, 'wolfcrypt', 'One line description of project.',
      'Miscellaneous'),
 ]


### PR DESCRIPTION
In Python 3, all strings are Unicode by default. The Unicode kind prefix is unnecessary and should be removed to avoid confusion.