### PR TITLE
Convert python project configuration to pyproject.toml.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+wolfCrypt-py Release next (TBD)
+==========================================
+
+* Drop support for end-of-life Python versions (<= 3.9)
+
+
 wolfCrypt-py Release 5.8.4 (Jan 7, 2026)
 ==========================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Security :: Cryptography",
     "Topic :: Software Development"
@@ -91,7 +95,7 @@ indent-width = 4
 # Assume Python 3.10
 target-version = "py310"
 
-[lint]
+[tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
@@ -105,7 +109,7 @@ unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[format]
+[tool.ruff.format]
 # Like Black, use double quotes for strings.
 quote-style = "double"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,133 @@
+[project]
+name = "wolfcrypt"
+description = "Python module that encapsulates wolfSSL's crypto engine API."
+readme = "README.rst"
+requires-python = ">=3.10"
+authors = [
+    {name = "wolfSSL Inc.", email="info@wolfssl.com"},
+]
+license = "GPL-2.0-only OR LicenseRef-WolfSSL"
+license-files = ["LICENSING.rst"]
+keywords = ["wolfssl", "wolfcrypt", "security", "cryptography"]
+classifiers = [
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: Security",
+    "Topic :: Security :: Cryptography",
+    "Topic :: Software Development"
+]
+dynamic = ["version"]
+dependencies = [
+    "cffi>=1.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/wolfssl/wolfcrypt-py"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta:__legacy__"
+
+[dependency-groups]
+dev = [
+    "mypy",
+    "pytest",
+    "ruff",
+    "sphinx",
+    "sphinx-rtd-theme",
+    "tox >= 4",
+    "ty",
+    "types-cffi",
+]
+
+[tool.tox]
+requires = ["tox>=4"]
+env_list = ["py3"]
+
+[tool.tox.env_run_base]
+package = "wheel"
+deps = ["-rrequirements/test.txt"]
+commands = [["py.test", "tests/"]]
+
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".idea",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "lib",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# The GitHub editor is 127 characters wide.
+line-length = 127
+indent-width = 4
+
+# Assume Python 3.10
+target-version = "py310"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F", "B", "UP"]
+ignore = ["UP031", "UP025", "UP032"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/setup.py
+++ b/setup.py
@@ -55,29 +55,10 @@ with open("LICENSING.rst") as licensing_file:
 setup(
     name="wolfcrypt",
     version=verstr,
-    description="Python module that encapsulates wolfSSL's crypto engine API.",
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    author="wolfSSL Inc.",
-    author_email="info@wolfssl.com",
-    url="https://github.com/wolfssl/wolfcrypt-py",
-    license="GPLv2 or Commercial License",
 
     packages=find_packages(),
-    keywords="wolfssl, wolfcrypt, security, cryptography",
-    classifiers=[
-        u"License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        u"License :: Other/Proprietary License",
-        u"Operating System :: OS Independent",
-        u"Programming Language :: Python :: 3",
-        u"Programming Language :: Python :: 3.6",
-        u"Programming Language :: Python :: 3.7",
-        u"Programming Language :: Python :: 3.8",
-        u"Programming Language :: Python :: 3.9",
-        u"Topic :: Security",
-        u"Topic :: Security :: Cryptography",
-        u"Topic :: Software Development"
-    ],
 
     setup_requires=["cffi>=1.0.0"],
     install_requires=["cffi>=1.0.0"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = py3
-
-[testenv]
-wheel = true
-
-deps = -rrequirements/test.txt
-commands = py.test tests/


### PR DESCRIPTION
Modern python projects standardize on pyproject.toml to reduce the number of configuration files required for all tools.