### PR TITLE
Use specific exception instead of bare except in build_ffi.py

### DIFF
--- a/scripts/build_ffi.py
+++ b/scripts/build_ffi.py
@@ -133,7 +133,7 @@ def checkout_version(version):
             current = subprocess.check_output(
                 ["git", "describe", "--all", "--exact-match"]
             ).strip().decode().split('/')[-1]
-        except:
+        except subprocess.CalledProcessError:
             pass
 
         if current != version:


### PR DESCRIPTION
A bare except catches BaseException which includes KeyboardInterrupt, SystemExit, Exception, and others.
Catching BaseException can make it hard to interrupt the program (e.g., with Ctrl-C) and can disguise other problems.