### PR TITLE
Remove unnecessary UTF-8 encoding declarations.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # wolfcrypt documentation build configuration file, created by
 # sphinx-quickstart on Fri Apr 29 16:47:53 2016.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2006-2022 wolfSSL Inc.
 #


### PR DESCRIPTION
PEP 3120 makes UTF-8 the default encoding, so a UTF-8 encoding declaration is unnecessary.