### PR TITLE
Remove redundant open modes.

### DIFF
--- a/scripts/build_ffi.py
+++ b/scripts/build_ffi.py
@@ -321,7 +321,7 @@ def get_features(local_wolfssl, features):
                 "fips.h")
 
     if fips_file and os.path.exists(fips_file):
-        with open(fips_file, "r") as f:
+        with open(fips_file) as f:
             contents = f.read()
             if not contents.isspace():
                 fips = True
@@ -347,7 +347,7 @@ def get_features(local_wolfssl, features):
 
     defines = []
     for file in defines_files:
-        with open(file, 'r') as f:
+        with open(file) as f:
             defines += f.read().splitlines()
 
     features["MPAPI"] = 1 if '#define WOLFSSL_PUBLIC_MP' in defines else 0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from setuptools import setup, find_packages
 os.chdir(os.path.dirname(sys.argv[0]) or ".")
 
 VERSIONFILE = "wolfcrypt/_version.py"
-verstrline = open(VERSIONFILE, "rt").read()
+verstrline = open(VERSIONFILE).read()
 VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
 mo = re.search(VSRE, verstrline, re.M)
 if mo:


### PR DESCRIPTION
Redundant `open` mode arguments are unnecessary and should be removed to avoid confusion.