### PR TITLE
Enable more ruff rules requiring only minor or no fixes.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,6 @@ indent-width = 4
 target-version = "py310"
 
 [tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
-# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
-# McCabe complexity (`C901`) by default.
 select = ["E", "F", "B", "UP", "C4", "DTZ", "EXE", "FA", "INT", "ISC", "ICN", "LOG", "G", "RSE", "SLOT", "TID", "TC", "FLY", "PERF", "W", "FURB"]
 ignore = ["E501"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,8 @@ target-version = "py310"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "B", "UP"]
-ignore = ["UP031", "UP025", "UP032"]
+select = ["E", "F", "B", "UP", "C4", "DTZ", "EXE", "FA", "INT", "ISC", "ICN", "LOG", "G", "RSE", "SLOT", "TID", "TC", "FLY", "PERF", "W", "FURB"]
+ignore = ["E501"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,13 @@ os.chdir(os.path.dirname(sys.argv[0]) or ".")
 VERSIONFILE = "wolfcrypt/_version.py"
 verstrline = open(VERSIONFILE).read()
 VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
-mo = re.search(VSRE, verstrline, re.M)
+mo = re.search(VSRE, verstrline, re.MULTILINE)
 if mo:
     verstr = mo.group(1)
 else:
     raise RuntimeError(f"Unable to find version string in {VERSIONFILE}.")
 VSRE = r"^__wolfssl_version__ = ['\"]([^'\"]*)['\"]"
-mo = re.search(VSRE, verstrline, re.M)
+mo = re.search(VSRE, verstrline, re.MULTILINE)
 if mo:
     wolfverstr = mo.group(1)
 else:

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -66,27 +66,27 @@ def vectors():
 
     if _lib.SHA256_ENABLED:
         vectorArray[Sha256]=TestVector(
-            digest=t2b("96e02e7b1cbcd6f104fe1fdb4652027a" +
+            digest=t2b("96e02e7b1cbcd6f104fe1fdb4652027a"
                        "5505b68652b70095c6318f9dce0d1844")
         )
 
     if _lib.SHA384_ENABLED:
         vectorArray[Sha384]=TestVector(
-            digest=t2b("4c79d80531203a16f91bee325f18c6aada47f9382fe44fc1" +
+            digest=t2b("4c79d80531203a16f91bee325f18c6aada47f9382fe44fc1"
                        "1f92917837e9b7902f5dccb7d3656f667a1dce3460bc884b")
         )
 
     if _lib.SHA512_ENABLED:
         vectorArray[Sha512]=TestVector(
-            digest=t2b("88fcf67ffd8558d713f9cedcd852db47" +
-                       "9e6573f0bd9955610a993f609637553c" +
-                       "e8fff55e644ee8a106aae19c07f91b3f" +
+            digest=t2b("88fcf67ffd8558d713f9cedcd852db47"
+                       "9e6573f0bd9955610a993f609637553c"
+                       "e8fff55e644ee8a106aae19c07f91b3f"
                        "2a2a6d40dfa7302c0fa6a1a9a5bfa03f")
         )
     if _lib.SHA3_ENABLED:
         vectorArray[Sha3]=TestVector(
-            digest=t2b("6170dedf06f83c3305ec18b7558384a5" +
-                       "a62d86e42c143d416aaec32f971986c1" +
+            digest=t2b("6170dedf06f83c3305ec18b7558384a5"
+                       "a62d86e42c143d416aaec32f971986c1"
                        "e84edf61df308cc6d8c310d1956e1908")
             )
     if _lib.HMAC_ENABLED:
@@ -96,18 +96,18 @@ def vectors():
             )
         if _lib.SHA256_ENABLED:
             vectorArray[HmacSha256]=TestVector(
-                digest=t2b("9041ac8c66fc350a1a0d5f4fff9d8ef74721d5a43ec8893a2" +
+                digest=t2b("9041ac8c66fc350a1a0d5f4fff9d8ef74721d5a43ec8893a2"
                            "875cf69576c45c2")
             )
         if _lib.SHA384_ENABLED:
             vectorArray[HmacSha384]=TestVector(
-                digest=t2b("f8c589ddf5489404f85c3c718a8345f207fb1ed6c6f5ecb09" +
+                digest=t2b("f8c589ddf5489404f85c3c718a8345f207fb1ed6c6f5ecb09"
                            "8e8be8aeb1aaa9f0c6dd84c141410b29a47a1a2b3a85ae0")
             )
         if _lib.SHA512_ENABLED:
             vectorArray[HmacSha512]=TestVector(
-                digest=t2b("7708a12ca110cd81a334bd4e8bddc4314acd3ed218bbff7c6" +
-                           "486e149fc145e9f5c05f05e919f7c2bc027266e986679984c" +
+                digest=t2b("7708a12ca110cd81a334bd4e8bddc4314acd3ed218bbff7c6"
+                           "486e149fc145e9f5c05f05e919f7c2bc027266e986679984c"
                            "3ade1a14084ad7627a65c3671a2d05")
             )
 


### PR DESCRIPTION
Extra rules:
All E pycodestyle error rules
C4   flake8-comprehensions
DTZ  flake8-datetimez
EXE  flake8-executable
FA   flake8-future-annotations
INT  flake8-gettext
ISC  flake8-implicit-str-concat
ICN  flake8-import-conventions
LOG  flake8-logging
G    flake8-logging-format
RSE  flake8-raise
SLOT flake8-slots
TID  flake8-tidy-imports
TC   flake8-type-checking
FLY  flynt
PERF Perflint
W    pycodestyle warnings
FURB refurb

Ignore E501:  line too long