### PR TITLE
Fix license in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,7 @@ requires-python = ">=3.10"
 authors = [
     {name = "wolfSSL Inc.", email="info@wolfssl.com"},
 ]
-license = "GPL-2.0-only OR LicenseRef-WolfSSL"
-license-files = ["LICENSING.rst"]
+license = {file = "LICENSING.rst"}
 keywords = ["wolfssl", "wolfcrypt", "security", "cryptography"]
 classifiers = [
     "Operating System :: OS Independent",


### PR DESCRIPTION
This change makes pyproject.toml compliant to PEP-621 w.r.t. license specification.

Update: changed to correct reference.