### PR TITLE
update license to GPLv3

### DIFF
--- a/LICENSING.rst
+++ b/LICENSING.rst
@@ -9,9 +9,9 @@ Open Source
 ~~~~~~~~~~~
 
 wolfCrypt and wolfSSL software are free software downloads and may be modified
-to the needs of the user as long as the user adheres to version two of the GPL
-License. The GPLv2 license can be found on the `gnu.org website
-<http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>`_.
+to the needs of the user as long as the user adheres to version three of the GPL
+License. The GPLv3 license can be found on the `gnu.org website
+<https://www.gnu.org/licenses/gpl-3.0.html>`_.
 
 Commercial Licensing
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,12 +1,12 @@
 # Makefile for Sphinx documentation
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # You can set these variables from the command line.
 SPHINXOPTS    =

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'wolfcrypt Python'
-copyright = '2022, wolfSSL Inc. All rights reserved'
+copyright = '2006-2026, wolfSSL Inc. All rights reserved'
 author = 'wolfSSL'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 authors = [
     {name = "wolfSSL Inc.", email="info@wolfssl.com"},
 ]
-license = "GPL-2.0-only OR LicenseRef-WolfSSL"
+license = "GPL-3.0-or-later OR LicenseRef-WolfSSL"
 license-files = ["LICENSING.rst"]
 keywords = ["wolfssl", "wolfcrypt", "security", "cryptography"]
 classifiers = [

--- a/scripts/build_ffi.py
+++ b/scripts/build_ffi.py
@@ -1,12 +1,12 @@
 # build_ffi.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=wrong-import-position
 

--- a/tests/test_aesgcmstream.py
+++ b/tests/test_aesgcmstream.py
@@ -1,12 +1,12 @@
 # test_aesgcmstream.py
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/test_asn.py
+++ b/tests/test_asn.py
@@ -1,12 +1,12 @@
 # test_asn.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/test_chacha20poly1305.py
+++ b/tests/test_chacha20poly1305.py
@@ -1,13 +1,13 @@
 
 # test_chacha20poly1305.py
 #
-# Copyright (C) 2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -17,7 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/test_ciphers.py
+++ b/tests/test_ciphers.py
@@ -1,12 +1,12 @@
 # test_ciphers.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/test_delete_descriptor_binding.py
+++ b/tests/test_delete_descriptor_binding.py
@@ -1,12 +1,12 @@
 # test_delete_descriptor_binding.py
 #
-# Copyright (C) 2026 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 """
 Regression tests guarding against the Python descriptor-binding bug on

--- a/tests/test_error_string.py
+++ b/tests/test_error_string.py
@@ -1,12 +1,12 @@
 # test_error_string.py
 #
-# Copyright (C) 2026 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 import pytest
 

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -1,12 +1,12 @@
 # test_hashes.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/test_hkdf.py
+++ b/tests/test_hkdf.py
@@ -1,12 +1,12 @@
 # test_hkdf.py
 #
-# Copyright (C) 2025 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/test_mldsa.py
+++ b/tests/test_mldsa.py
@@ -1,12 +1,12 @@
 # test_mldsa.py
 #
-# Copyright (C) 2025 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/test_mlkem.py
+++ b/tests/test_mlkem.py
@@ -1,12 +1,12 @@
 # test_mlkem.py
 #
-# Copyright (C) 2025 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/tests/test_pwdbased.py
+++ b/tests/test_pwdbased.py
@@ -1,12 +1,12 @@
 # test_pwdbased.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 from collections import namedtuple

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,12 +1,12 @@
 # test_random.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=redefined-outer-name
 

--- a/wolfcrypt/__init__.py
+++ b/wolfcrypt/__init__.py
@@ -1,12 +1,12 @@
 # __init__.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 from wolfcrypt._version import __version__, __wolfssl_version__
 
@@ -27,8 +27,8 @@ __uri__ = "https://github.com/wolfssl/wolfcrypt-py"
 __author__ = "wolfSSL Inc."
 __email__ = "info@wolfssl.com"
 
-__license__ = "GPLv2 or Commercial License"
-__copyright__ = "Copyright (C) 2006-2022 wolfSSL Inc"
+__license__ = "GPLv3-or-later or Commercial License"
+__copyright__ = "Copyright (C) 2006-2026 wolfSSL Inc"
 
 __all__ = [
     "__title__", "__summary__", "__uri__", "__version__", "__wolfssl_version__",

--- a/wolfcrypt/asn.py
+++ b/wolfcrypt/asn.py
@@ -1,12 +1,12 @@
 # asn.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=no-member,no-name-in-module
 

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -1,12 +1,12 @@
 # ciphers.py
 #
-# Copyright (C) 2006-2025 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=no-member,no-name-in-module
 

--- a/wolfcrypt/exceptions.py
+++ b/wolfcrypt/exceptions.py
@@ -1,12 +1,12 @@
 # exceptions.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 
 from wolfcrypt._ffi import ffi as _ffi

--- a/wolfcrypt/hashes.py
+++ b/wolfcrypt/hashes.py
@@ -1,12 +1,12 @@
 # hashes.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=no-member,no-name-in-module, no-self-use
 

--- a/wolfcrypt/hkdf.py
+++ b/wolfcrypt/hkdf.py
@@ -1,12 +1,12 @@
 # hkdf.py
 #
-# Copyright (C) 2025 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=no-member,no-name-in-module
 

--- a/wolfcrypt/pwdbased.py
+++ b/wolfcrypt/pwdbased.py
@@ -1,12 +1,12 @@
 # pwdbased.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=no-member,no-name-in-module
 

--- a/wolfcrypt/random.py
+++ b/wolfcrypt/random.py
@@ -1,12 +1,12 @@
 # random.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=no-member,no-name-in-module
 

--- a/wolfcrypt/utils.py
+++ b/wolfcrypt/utils.py
@@ -1,12 +1,12 @@
 # utils.py
 #
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
-# This file is part of wolfSSL. (formerly known as CyaSSL)
+# This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
 # pylint: disable=unused-import
 


### PR DESCRIPTION
wolfSSL is GPLv3 with special exceptions for GPLv2. Update the license to reflect the GPLv3 status.