### PR TITLE
Clean up setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
     "types-cffi",
 ]
 
+[tool.setuptools.packages.find]
+include = ["wolfcrypt", "wolfcrypt._ffi"]
+
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@
 import os
 import re
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 
 os.chdir(os.path.dirname(sys.argv[0]) or ".")
 
@@ -47,20 +47,11 @@ else:
 with open("README.rst") as readme_file:
     long_description = readme_file.read()
 
-with open("LICENSING.rst") as licensing_file:
-    long_description = long_description.replace(".. include:: LICENSING.rst\n",
-                                                licensing_file.read())
-
 setup(
     name="wolfcrypt",
     version=verstr,
     long_description=long_description,
     long_description_content_type='text/x-rst',
 
-    packages=find_packages(),
-
-    setup_requires=["cffi>=1.17"],
     cffi_modules=["./scripts/build_ffi.py:ffibuilder"],
-
-    package_data={"wolfcrypt": ["*.dll", "**/*.pyi", "py.typed"]},
 )


### PR DESCRIPTION
- remove obsolete merging of LICENSING.rst in description as the include is not there anymore
- put setuptools configuration in pyproject.toml
- the setup_requires setting in setup.py is deprecated and is covered by pyproject.toml [build-system] - requires