### PR TITLE
build: declare the setuptools build backend floor (F-5426)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
 Homepage = "https://github.com/wolfssl/wolfcrypt-py"
 
 [build-system]
-requires = ["setuptools", "cffi>=1.17"]
+# setuptools >= 77 is required for the PEP 639 `license` expression and
+# `license-files` above; 76 and older reject them.
+requires = ["setuptools>=77", "cffi>=1.17"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [dependency-groups]


### PR DESCRIPTION
## Problem

`pyproject.toml` declares `setuptools` as a PEP 517 build requirement with no version bound:

```toml
requires = ["setuptools", "cffi>=1.17"]
```

In an isolated build (the PEP 517 default), the frontend resolves whatever `setuptools` the index currently serves before running the backend. This repo has no `uv.lock`, so CI's `uv build --wheel` re-resolves the backend on every run.

Nothing is broken today: an unpinned resolver always picks a recent backend, so the build works. This is about declaring what the project actually requires.

## Fix

```toml
requires = ["setuptools>=77", "cffi>=1.17"]
```

**The floor is measured, not chosen.** The PEP 639 `license = "GPL-3.0-or-later OR LicenseRef-WolfSSL"` expression and the `license-files` key already in this file each require `setuptools >= 77` *independently* — 76.1.0 rejects either one on its own, while the older `license = {file = ...}` table form passes. So the project already had an undeclared `>= 77` requirement that stayed invisible precisely because the version floated. Without this, a build environment that pins below 77 for unrelated reasons fails mid-build on an opaque `project.license must be valid exactly by one definition` error, with no hint that the fix is a `setuptools` upgrade.

**No upper bound**, which is a change from the first version of this PR. Reasons:

- A ceiling does not address the reported risk. A malicious point release satisfies any range; only hash-pinned build requirements help there.
- `setuptools` has shipped 7 majors since 2025-03 (81 and 82 two days apart). A ceiling needs bumping several times a year, and a stale one silently excludes working versions instead of protecting anything — this PR's original `<81` already excluded the current 83.
- Every other bound in this file is floor-only (`cffi>=1.17`, `typing-extensions>=4.4.0`).

Hash-pinning the build environment for release builds is the real mitigation for index compromise; that is out of scope here and tracked separately.

## Verification

- Builds at both 77.0.3 and 83.0.0
- 76.1.0 correctly refused at resolve time: `No solution found when resolving: setuptools>=77`
- `License-Expression: GPL-3.0-or-later OR LicenseRef-WolfSSL` intact in wheel `METADATA`
- `ruff check` clean; `pytest tests` 196 passed, 7 skipped

Reported by static analysis (Fenrir finding F-5426).

`[fenrir-sweep:released]`
