### PR TITLE
Use byte ctxLen in wc_dilithium_verify_ctx_msg cdef (F-4014)

### DIFF
--- a/scripts/build_ffi.py
+++ b/scripts/build_ffi.py
@@ -1350,7 +1350,7 @@ def build_ffi(local_wolfssl, features):
         int wc_dilithium_import_public(const byte* in, word32 inLen, dilithium_key* key);
         int wc_dilithium_sign_ctx_msg(const byte* ctx, byte ctxLen, const byte* msg, word32 msgLen, byte* sig, word32* sigLen, dilithium_key* key, WC_RNG* rng);
         int wc_dilithium_sign_ctx_msg_with_seed(const byte* ctx, byte ctxLen, const byte* msg, word32 msgLen, byte* sig, word32* sigLen, dilithium_key* key, const byte* seed);
-        int wc_dilithium_verify_ctx_msg(const byte* sig, word32 sigLen, const byte* ctx, word32 ctxLen, const byte* msg, word32 msgLen, int* res, dilithium_key* key);
+        int wc_dilithium_verify_ctx_msg(const byte* sig, word32 sigLen, const byte* ctx, byte ctxLen, const byte* msg, word32 msgLen, int* res, dilithium_key* key);
         typedef dilithium_key MlDsaKey;
         int wc_MlDsaKey_GetPrivLen(MlDsaKey* key, int* len);
         int wc_MlDsaKey_GetPubLen(MlDsaKey* key, int* len);

--- a/wolfcrypt/ciphers.py
+++ b/wolfcrypt/ciphers.py
@@ -2364,6 +2364,10 @@ if _lib.ML_DSA_ENABLED:
 
             if ctx is not None:
                 ctx_bytestype = t2b(ctx)
+                if len(ctx_bytestype) > 255:
+                    raise ValueError(
+                        f"context length {len(ctx_bytestype)} too large: must be 255 or less"
+                    )
                 ret = _lib.wc_dilithium_verify_ctx_msg(
                     sig_bytestype,
                     len(sig_bytestype),


### PR DESCRIPTION
### Description

The CFFI cdef for `wc_dilithium_verify_ctx_msg` declared `ctxLen` as `word32`, while the sign variants (`wc_dilithium_sign_ctx_msg`, `wc_dilithium_sign_ctx_msg_with_seed`) declare it as `byte`.

wolfSSL's real API is `wc_MlDsaKey_VerifyCtx` (`wolfssl/wolfcrypt/wc_mldsa.h`), which the `wc_dilithium_verify_ctx_msg` macro forwards to, and it takes `byte ctxLen` — matching FIPS 204's 255-byte context cap.

The mismatched cdef made CFFI marshal a 4-byte `word32` into a 1-byte slot, silently truncating any `ctxLen > 255` to its low byte.

This declares `ctxLen` as `byte` so the cdef matches both the sign cdefs and the underlying API.

### Fixes

F-4014
